### PR TITLE
Run tests on a background thread

### DIFF
--- a/src/runner/nunit.runner/View/ResultsView.xaml
+++ b/src/runner/nunit.runner/View/ResultsView.xaml
@@ -11,7 +11,8 @@
             <ListView ItemsSource="{Binding Results}" 
                       ItemSelected="ViewTest"
                       VerticalOptions="FillAndExpand" 
-                      HorizontalOptions="FillAndExpand">
+                      HorizontalOptions="FillAndExpand"
+                      HasUnevenRows="true">
                 <ListView.ItemTemplate>
                     <DataTemplate>
                         <ViewCell>

--- a/src/runner/nunit.runner/View/ResultsView.xaml.cs
+++ b/src/runner/nunit.runner/View/ResultsView.xaml.cs
@@ -21,16 +21,17 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System.Threading.Tasks;
-using NUnit.Framework.Interfaces;
 using NUnit.Runner.ViewModel;
 using Xamarin.Forms;
 
 namespace NUnit.Runner.View
 {
-	public partial class ResultsView : ContentPage
+    /// <summary>
+    /// Xamarin.Forms view of a list of test results
+    /// </summary>
+    public partial class ResultsView : ContentPage
 	{
-		public ResultsView (ResultsViewModel model)
+		internal ResultsView (ResultsViewModel model)
         {
             model.Navigation = Navigation;
             BindingContext = model;

--- a/src/runner/nunit.runner/View/SummaryView.xaml
+++ b/src/runner/nunit.runner/View/SummaryView.xaml
@@ -4,6 +4,11 @@
              x:Class="NUnit.Runner.View.SummaryView"
              Title="NUnit 3.0"
              Padding="6">
+    <ContentPage.Triggers>
+        <DataTrigger TargetType="ContentPage" Binding="{Binding Running}" Value="True">
+            <Setter Property="IsBusy" Value="True" />
+        </DataTrigger>
+    </ContentPage.Triggers>
     <StackLayout Orientation="Vertical" Spacing="4" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand">
         <Button Text="Run Tests" Command="{Binding RunTestsCommand}"  HorizontalOptions="FillAndExpand">
             <Button.Triggers>

--- a/src/runner/nunit.runner/View/SummaryView.xaml.cs
+++ b/src/runner/nunit.runner/View/SummaryView.xaml.cs
@@ -35,7 +35,7 @@ namespace NUnit.Runner.View
 		{
 		    model.Navigation = Navigation;
 		    BindingContext = model;
-			InitializeComponent ();
+			InitializeComponent();
 		}
 	}
 }

--- a/src/runner/nunit.runner/View/SummaryView.xaml.cs
+++ b/src/runner/nunit.runner/View/SummaryView.xaml.cs
@@ -26,9 +26,12 @@ using Xamarin.Forms;
 
 namespace NUnit.Runner.View
 {
+    /// <summary>
+    /// The main Xamarin.Forms view of the application
+    /// </summary>
 	public partial class SummaryView : ContentPage
 	{
-		public SummaryView (SummaryViewModel model)
+		internal SummaryView (SummaryViewModel model)
 		{
 		    model.Navigation = Navigation;
 		    BindingContext = model;

--- a/src/runner/nunit.runner/View/TestView.xaml.cs
+++ b/src/runner/nunit.runner/View/TestView.xaml.cs
@@ -26,9 +26,12 @@ using Xamarin.Forms;
 
 namespace NUnit.Runner.View
 {
+    /// <summary>
+    /// Xamarin.Forms view of an individual test result
+    /// </summary>
 	public partial class TestView : ContentPage
 	{
-		public TestView(TestViewModel model)
+		internal TestView(TestViewModel model)
         {
             BindingContext = model;
             InitializeComponent();

--- a/src/runner/nunit.runner/ViewModel/BaseViewModel.cs
+++ b/src/runner/nunit.runner/ViewModel/BaseViewModel.cs
@@ -28,7 +28,7 @@ using Xamarin.Forms;
 
 namespace NUnit.Runner.ViewModel
 {
-    public class BaseViewModel : INotifyPropertyChanged
+    class BaseViewModel : INotifyPropertyChanged
     {
         /// <summary>
         /// So that we can navigate from within the view model

--- a/src/runner/nunit.runner/ViewModel/ResultViewModel.cs
+++ b/src/runner/nunit.runner/ViewModel/ResultViewModel.cs
@@ -21,15 +21,13 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System.Windows.Input;
 using NUnit.Framework.Interfaces;
 using NUnit.Runner.Extensions;
-using NUnit.Runner.View;
 using Xamarin.Forms;
 
 namespace NUnit.Runner.ViewModel
 {
-    public class ResultViewModel
+    internal class ResultViewModel
     {
         public ResultViewModel(ITestResult result)
         {

--- a/src/runner/nunit.runner/ViewModel/ResultsViewModel.cs
+++ b/src/runner/nunit.runner/ViewModel/ResultsViewModel.cs
@@ -29,7 +29,7 @@ using Xamarin.Forms;
 
 namespace NUnit.Runner.ViewModel
 {
-    public class ResultsViewModel : BaseViewModel
+    class ResultsViewModel : BaseViewModel
     {
         /// <summary>
         /// Constructs the view model

--- a/src/runner/nunit.runner/ViewModel/SummaryViewModel.cs
+++ b/src/runner/nunit.runner/ViewModel/SummaryViewModel.cs
@@ -34,7 +34,7 @@ using Xamarin.Forms;
 
 namespace NUnit.Runner.ViewModel
 {
-    public class SummaryViewModel : BaseViewModel
+    class SummaryViewModel : BaseViewModel
     {
         private readonly IList<Assembly> _testAssemblies;
         private ResultSummary _results;

--- a/src/runner/nunit.runner/ViewModel/SummaryViewModel.cs
+++ b/src/runner/nunit.runner/ViewModel/SummaryViewModel.cs
@@ -103,19 +103,25 @@ namespace NUnit.Runner.ViewModel
             _testAssemblies.Add(testAssembly);
         }
 
-        private async Task ExecuteTestsAync()
+        async Task ExecuteTestsAync()
         {
             Running = true;
             Results = null;
 
-            var runner = new NUnitTestAssemblyRunner(new DefaultTestAssemblyBuilder());
-            foreach(var testAssembly in _testAssemblies)
-                runner.Load(testAssembly, new Dictionary<string, string>());
+            var runner = await LoadTestAssembliesAsync();
 
             ITestResult result = await Task.Run(() => runner.Run(TestListener.NULL, TestFilter.Empty));
             Results = new ResultSummary(result);
 
             Running = false;
+        }
+
+        async Task<NUnitTestAssemblyRunner> LoadTestAssembliesAsync()
+        {
+            var runner = new NUnitTestAssemblyRunner(new DefaultTestAssemblyBuilder());
+            foreach (var testAssembly in _testAssemblies)
+                await Task.Run(() => runner.Load(testAssembly, new Dictionary<string, string>()));
+            return runner;
         }
     }
 }

--- a/src/runner/nunit.runner/ViewModel/TestViewModel.cs
+++ b/src/runner/nunit.runner/ViewModel/TestViewModel.cs
@@ -29,7 +29,7 @@ using Xamarin.Forms;
 
 namespace NUnit.Runner.ViewModel
 {
-    public class TestViewModel : BaseViewModel
+    class TestViewModel : BaseViewModel
     {
         public TestViewModel(ITestResult result) 
         {


### PR DESCRIPTION
Fixes #13

- Fixes build warnings
- Tests were already running on a background thread, but the loading of test assemblies was not. Fixed.
- UI now displays a busy icon while tests are running and loading.