### PR TITLE
Add TcpWriter and save XmlResult file to device

### DIFF
--- a/nuget/MonoAndroid10/MainActivity.cs.txt.pp
+++ b/nuget/MonoAndroid10/MainActivity.cs.txt.pp
@@ -42,8 +42,20 @@ namespace $rootnamespace$
             // If you want to add tests in another assembly
             //nunit.AddTestAssembly(typeof(MyTests).Assembly);
 
-            // Do you want to automatically run tests when the app starts?
-            nunit.AutoRun = true;
+            // Available options for testing
+            nunit.Options = new TestOptions
+                {
+                    // If True, the tests will run automatically when the app starts
+                    // otherwise you must run them manually.
+                    AutoRun = true,
+
+                    // Information about the tcp listener host and port.
+                    // For now, send result as XML to the listening server.
+                    // TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000),
+
+                    // Creates a NUnit Xml result file on the host file system using PCLStorage library.
+                    CreateXmlResultFile = false
+                };
 
             LoadApplication(nunit);
         }

--- a/nuget/MonoAndroid10/MainActivity.cs.txt.pp
+++ b/nuget/MonoAndroid10/MainActivity.cs.txt.pp
@@ -44,18 +44,18 @@ namespace $rootnamespace$
 
             // Available options for testing
             nunit.Options = new TestOptions
-                {
-                    // If True, the tests will run automatically when the app starts
-                    // otherwise you must run them manually.
-                    AutoRun = true,
+            {
+                // If True, the tests will run automatically when the app starts
+                // otherwise you must run them manually.
+                AutoRun = true,
 
-                    // Information about the tcp listener host and port.
-                    // For now, send result as XML to the listening server.
-                    // TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000),
+                // Information about the tcp listener host and port.
+                // For now, send result as XML to the listening server.
+                // TcpWriterParameters = new TcpWriterInfo("192.168.0.108", 13000),
 
-                    // Creates a NUnit Xml result file on the host file system using PCLStorage library.
-                    CreateXmlResultFile = false
-                };
+                // Creates a NUnit Xml result file on the host file system using PCLStorage library.
+                CreateXmlResultFile = false
+            };
 
             LoadApplication(nunit);
         }

--- a/nuget/Xamarin.iOS10/AppDelegate.cs.txt.pp
+++ b/nuget/Xamarin.iOS10/AppDelegate.cs.txt.pp
@@ -49,8 +49,20 @@ namespace $rootnamespace$
             // If you want to add tests in another assembly
             //nunit.AddTestAssembly(typeof(MyTests).Assembly);
 
-            // Do you want to automatically run tests when the app starts?
-            nunit.AutoRun = true;
+            // Available options for testing
+            nunit.Options = new TestOptions
+                {
+                    // If True, the tests will run automatically when the app starts
+                    // otherwise you must run them manually.
+                    AutoRun = true,
+
+                    // Information about the tcp listener host and port.
+                    // For now, send result as XML to the listening server.
+                    // TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000),
+
+                    // Creates a NUnit Xml result file on the host file system using PCLStorage library.
+                    CreateXmlResultFile = false
+                };
 
             LoadApplication(nunit);
 

--- a/nuget/Xamarin.iOS10/AppDelegate.cs.txt.pp
+++ b/nuget/Xamarin.iOS10/AppDelegate.cs.txt.pp
@@ -51,18 +51,18 @@ namespace $rootnamespace$
 
             // Available options for testing
             nunit.Options = new TestOptions
-                {
-                    // If True, the tests will run automatically when the app starts
-                    // otherwise you must run them manually.
-                    AutoRun = true,
+            {
+                // If True, the tests will run automatically when the app starts
+                // otherwise you must run them manually.
+                AutoRun = true,
 
-                    // Information about the tcp listener host and port.
-                    // For now, send result as XML to the listening server.
-                    // TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000),
+                // Information about the tcp listener host and port.
+                // For now, send result as XML to the listening server.
+                // TcpWriterParameters = new TcpWriterInfo("192.168.0.108", 13000),
 
-                    // Creates a NUnit Xml result file on the host file system using PCLStorage library.
-                    CreateXmlResultFile = false
-                };
+                // Creates a NUnit Xml result file on the host file system using PCLStorage library.
+                CreateXmlResultFile = false
+            };
 
             LoadApplication(nunit);
 

--- a/nuget/nunit.runners.xamarin.nuspec
+++ b/nuget/nunit.runners.xamarin.nuspec
@@ -26,6 +26,7 @@ Supported Xamarin platforms:
             <group>
                 <dependency id="nunit" version="[3.0.1]" />
                 <dependency id="Xamarin.Forms" version="1.5.0.6447" />
+                <dependency id="PCLStorage" version="1.0.2" />
             </group>
         </dependencies>
     </metadata>

--- a/nuget/uap10.0/MainPage.xaml.cs.txt.pp
+++ b/nuget/uap10.0/MainPage.xaml.cs.txt.pp
@@ -38,8 +38,20 @@ namespace $rootnamespace$
             // duplicate the following line with a type from the referenced assembly
             nunit.AddTestAssembly(typeof(MainPage).GetTypeInfo().Assembly);
 
-            // Do you want to automatically run tests when the app starts?
-            nunit.AutoRun = true;
+            // Available options for testing
+            nunit.Options = new TestOptions
+                {
+                    // If True, the tests will run automatically when the app starts
+                    // otherwise you must run them manually.
+                    AutoRun = true,
+
+                    // Information about the tcp listener host and port.
+                    // For now, send result as XML to the listening server.
+                    // TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000),
+
+                    // Creates a NUnit Xml result file on the host file system using PCLStorage library.
+                    CreateXmlResultFile = false
+                };
 
             LoadApplication(nunit);
         }

--- a/nuget/uap10.0/MainPage.xaml.cs.txt.pp
+++ b/nuget/uap10.0/MainPage.xaml.cs.txt.pp
@@ -40,18 +40,19 @@ namespace $rootnamespace$
 
             // Available options for testing
             nunit.Options = new TestOptions
-                {
-                    // If True, the tests will run automatically when the app starts
-                    // otherwise you must run them manually.
-                    AutoRun = true,
+            {
+                // If True, the tests will run automatically when the app starts
+                // otherwise you must run them manually.
+                AutoRun = true,
 
-                    // Information about the tcp listener host and port.
-                    // For now, send result as XML to the listening server.
-                    // TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000),
+                // Information about the tcp listener host and port.
+                // For now, send result as XML to the listening server.
+                // NOTE: Your UWP App must have Private Networks capability enabled
+                //TcpWriterParameters = new TcpWriterInfo("192.168.0.108", 13000),
 
-                    // Creates a NUnit Xml result file on the host file system using PCLStorage library.
-                    CreateXmlResultFile = false
-                };
+                // Creates a NUnit Xml result file on the host file system using PCLStorage library.
+                CreateXmlResultFile = false
+            };
 
             LoadApplication(nunit);
         }

--- a/nuget/wpa81/MainPage.xaml.cs.txt.pp
+++ b/nuget/wpa81/MainPage.xaml.cs.txt.pp
@@ -39,8 +39,20 @@ namespace $rootnamespace$
             // duplicate the following line with a type from the referenced assembly
             nunit.AddTestAssembly(typeof(MainPage).GetTypeInfo().Assembly);
 
-            // Do you want to automatically run tests when the app starts?
-            nunit.AutoRun = true;
+            // Available options for testing
+            nunit.Options = new TestOptions
+                {
+                    // If True, the tests will run automatically when the app starts
+                    // otherwise you must run them manually.
+                    AutoRun = true,
+
+                    // Information about the tcp listener host and port.
+                    // For now, send result as XML to the listening server.
+                    // TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000),
+
+                    // Creates a NUnit Xml result file on the host file system using PCLStorage library.
+                    CreateXmlResultFile = false
+                };
 
             LoadApplication(nunit);
 

--- a/nuget/wpa81/MainPage.xaml.cs.txt.pp
+++ b/nuget/wpa81/MainPage.xaml.cs.txt.pp
@@ -41,18 +41,18 @@ namespace $rootnamespace$
 
             // Available options for testing
             nunit.Options = new TestOptions
-                {
-                    // If True, the tests will run automatically when the app starts
-                    // otherwise you must run them manually.
-                    AutoRun = true,
+            {
+                // If True, the tests will run automatically when the app starts
+                // otherwise you must run them manually.
+                AutoRun = true,
 
-                    // Information about the tcp listener host and port.
-                    // For now, send result as XML to the listening server.
-                    // TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000),
+                // Information about the tcp listener host and port.
+                // For now, send result as XML to the listening server.
+                // TcpWriterParameters = new TcpWriterInfo("192.168.0.108", 13000),
 
-                    // Creates a NUnit Xml result file on the host file system using PCLStorage library.
-                    CreateXmlResultFile = false
-                };
+                // Creates a NUnit Xml result file on the host file system using PCLStorage library.
+                CreateXmlResultFile = false
+            };
 
             LoadApplication(nunit);
 

--- a/nunit.runner.sln.DotSettings
+++ b/nunit.runner.sln.DotSettings
@@ -37,7 +37,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.&#xD;
 </s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/@KeyIndexDefined">True</s:Boolean>
 	
 	

--- a/src/runner/nunit.runner.Droid/nunit.runner.Droid.csproj
+++ b/src/runner/nunit.runner.Droid/nunit.runner.Droid.csproj
@@ -49,6 +49,14 @@
       <HintPath>..\..\..\packages\NUnit.3.0.1\lib\dotnet\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="PCLStorage, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\PCLStorage.1.0.2\lib\monoandroid\PCLStorage.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="PCLStorage.Abstractions, Version=1.0.2.0, Culture=neutral, PublicKeyToken=286fe515a2c35b64, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\PCLStorage.1.0.2\lib\monoandroid\PCLStorage.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/src/runner/nunit.runner.Droid/packages.config
+++ b/src/runner/nunit.runner.Droid/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="3.0.1" targetFramework="monoandroid60" />
+  <package id="PCLStorage" version="1.0.2" targetFramework="monoandroid60" />
   <package id="Xamarin.Android.Support.v4" version="23.0.1.3" targetFramework="monoandroid403" />
   <package id="Xamarin.Forms" version="1.5.0.6447" targetFramework="monoandroid51" />
 </packages>

--- a/src/runner/nunit.runner.iOS/nunit.runner.iOS.csproj
+++ b/src/runner/nunit.runner.iOS/nunit.runner.iOS.csproj
@@ -43,6 +43,14 @@
       <HintPath>..\..\..\packages\NUnit.3.0.1\lib\dotnet\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="PCLStorage, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\PCLStorage.1.0.2\lib\portable-Xamarin.iOS+Xamarin.Mac\PCLStorage.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="PCLStorage.Abstractions, Version=1.0.2.0, Culture=neutral, PublicKeyToken=286fe515a2c35b64, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\PCLStorage.1.0.2\lib\portable-Xamarin.iOS+Xamarin.Mac\PCLStorage.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />

--- a/src/runner/nunit.runner.iOS/packages.config
+++ b/src/runner/nunit.runner.iOS/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="3.0.1" targetFramework="xamarinios10" />
+  <package id="PCLStorage" version="1.0.2" targetFramework="xamarinios10" />
   <package id="Xamarin.Forms" version="1.5.0.6447" targetFramework="xamarinios1" />
 </packages>

--- a/src/runner/nunit.runner.uwp/project.json
+++ b/src/runner/nunit.runner.uwp/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0",
     "NUnit": "3.0.1",
+    "PCLStorage": "1.0.2",
     "Xamarin.Forms": "1.5.0.6447"
   },
   "frameworks": {

--- a/src/runner/nunit.runner.uwp/project.lock.json
+++ b/src/runner/nunit.runner.uwp/project.lock.json
@@ -209,6 +209,16 @@
           "lib/dotnet/nunit.framework.dll": {}
         }
       },
+      "PCLStorage/1.0.2": {
+        "compile": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        },
+        "runtime": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        }
+      },
       "System.AppContext/4.0.0": {
         "dependencies": {
           "System.Collections": "[4.0.0, )",
@@ -1809,6 +1819,16 @@
         },
         "runtime": {
           "lib/dotnet/nunit.framework.dll": {}
+        }
+      },
+      "PCLStorage/1.0.2": {
+        "compile": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        },
+        "runtime": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
         }
       },
       "System.AppContext/4.0.0": {
@@ -3444,6 +3464,16 @@
         },
         "runtime": {
           "lib/dotnet/nunit.framework.dll": {}
+        }
+      },
+      "PCLStorage/1.0.2": {
+        "compile": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        },
+        "runtime": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
         }
       },
       "System.AppContext/4.0.0": {
@@ -5086,6 +5116,16 @@
           "lib/dotnet/nunit.framework.dll": {}
         }
       },
+      "PCLStorage/1.0.2": {
+        "compile": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        },
+        "runtime": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        }
+      },
       "System.AppContext/4.0.0": {
         "dependencies": {
           "System.Collections": "[4.0.0, )",
@@ -6719,6 +6759,16 @@
         },
         "runtime": {
           "lib/dotnet/nunit.framework.dll": {}
+        }
+      },
+      "PCLStorage/1.0.2": {
+        "compile": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        },
+        "runtime": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
         }
       },
       "System.AppContext/4.0.0": {
@@ -8361,6 +8411,16 @@
           "lib/dotnet/nunit.framework.dll": {}
         }
       },
+      "PCLStorage/1.0.2": {
+        "compile": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        },
+        "runtime": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        }
+      },
       "System.AppContext/4.0.0": {
         "dependencies": {
           "System.Collections": "[4.0.0, )",
@@ -9994,6 +10054,16 @@
         },
         "runtime": {
           "lib/dotnet/nunit.framework.dll": {}
+        }
+      },
+      "PCLStorage/1.0.2": {
+        "compile": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        },
+        "runtime": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
         }
       },
       "System.AppContext/4.0.0": {
@@ -12057,6 +12127,52 @@
         "NOTICES.txt",
         "NUnit.nuspec",
         "package/services/metadata/core-properties/59ec910f17c54b6493a6276f36784454.psmdcp"
+      ]
+    },
+    "PCLStorage/1.0.2": {
+      "sha512": "9If+1ZFCk3QaT/asfiL+J9FMnx2CTMrLCU8tDMUOI/aCGWGWl9vJ1/KcMkjf92op23ZknenvYJZBLDAqE3sFlg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/monoandroid/PCLStorage.Abstractions.dll",
+        "lib/monoandroid/PCLStorage.Abstractions.xml",
+        "lib/monoandroid/PCLStorage.dll",
+        "lib/monoandroid/PCLStorage.xml",
+        "lib/monotouch/PCLStorage.Abstractions.dll",
+        "lib/monotouch/PCLStorage.Abstractions.xml",
+        "lib/monotouch/PCLStorage.dll",
+        "lib/monotouch/PCLStorage.xml",
+        "lib/net45/PCLStorage.Abstractions.dll",
+        "lib/net45/PCLStorage.Abstractions.xml",
+        "lib/net45/PCLStorage.dll",
+        "lib/net45/PCLStorage.xml",
+        "lib/portable-net45+sl5+wp8+wpa81+win8+monoandroid+monotouch+Xamarin.iOS+Xamarin.Mac/PCLStorage.Abstractions.dll",
+        "lib/portable-net45+sl5+wp8+wpa81+win8+monoandroid+monotouch+Xamarin.iOS+Xamarin.Mac/PCLStorage.Abstractions.xml",
+        "lib/portable-net45+sl5+wp8+wpa81+win8+monoandroid+monotouch+Xamarin.iOS+Xamarin.Mac/PCLStorage.dll",
+        "lib/portable-net45+sl5+wp8+wpa81+win8+monoandroid+monotouch+Xamarin.iOS+Xamarin.Mac/PCLStorage.xml",
+        "lib/portable-net45+wp8+wpa81+win8+monoandroid+monotouch+Xamarin.iOS+Xamarin.Mac/PCLStorage.Abstractions.dll",
+        "lib/portable-net45+wp8+wpa81+win8+monoandroid+monotouch+Xamarin.iOS+Xamarin.Mac/PCLStorage.Abstractions.xml",
+        "lib/portable-net45+wp8+wpa81+win8+monoandroid+monotouch+Xamarin.iOS+Xamarin.Mac/PCLStorage.dll",
+        "lib/portable-net45+wp8+wpa81+win8+monoandroid+monotouch+Xamarin.iOS+Xamarin.Mac/PCLStorage.xml",
+        "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll",
+        "lib/portable-win8+wpa81/PCLStorage.Abstractions.xml",
+        "lib/portable-win8+wpa81/PCLStorage.dll",
+        "lib/portable-win8+wpa81/PCLStorage.xml",
+        "lib/portable-Xamarin.iOS+Xamarin.Mac/PCLStorage.Abstractions.dll",
+        "lib/portable-Xamarin.iOS+Xamarin.Mac/PCLStorage.Abstractions.xml",
+        "lib/portable-Xamarin.iOS+Xamarin.Mac/PCLStorage.dll",
+        "lib/portable-Xamarin.iOS+Xamarin.Mac/PCLStorage.xml",
+        "lib/sl5/PCLStorage.Abstractions.dll",
+        "lib/sl5/PCLStorage.Abstractions.xml",
+        "lib/sl5/PCLStorage.dll",
+        "lib/sl5/PCLStorage.xml",
+        "lib/wp8/PCLStorage.Abstractions.dll",
+        "lib/wp8/PCLStorage.Abstractions.xml",
+        "lib/wp8/PCLStorage.dll",
+        "lib/wp8/PCLStorage.xml",
+        "package/services/metadata/core-properties/dba2944eebe04ff298a58a04f2282910.psmdcp",
+        "PCLStorage.nuspec"
       ]
     },
     "System.AppContext/4.0.0": {
@@ -14838,6 +14954,7 @@
     "": [
       "Microsoft.NETCore.UniversalWindowsPlatform >= 5.0.0",
       "NUnit >= 3.0.1",
+      "PCLStorage >= 1.0.2",
       "Xamarin.Forms >= 1.5.0.6447"
     ],
     "UAP,Version=v10.0": []

--- a/src/runner/nunit.runner.uwp/project.lock.json
+++ b/src/runner/nunit.runner.uwp/project.lock.json
@@ -14871,7 +14871,7 @@
       ]
     },
     "Xamarin.Forms/1.5.0.6447": {
-      "sha512": "iPmiog6UF5ZZNyE0faRdWhGlVaoqVRi193wyeStwRxX6l3QNomMFBaHN58ly2vOuKD2KYk+McjBOEQi6HfNwEA==",
+      "sha512": "0oBfhFmKt4kxFK+iBdTtZaW6Ys/adM7fH/47EcHLXfsNoe34xtYAqEZ7A4lGMnzg/5hgRVHmiOV2Z0cmZvuTwg==",
       "type": "Package",
       "files": [
         "[Content_Types].xml",

--- a/src/runner/nunit.runner.wp81/nunit.runner.wp81.csproj
+++ b/src/runner/nunit.runner.wp81/nunit.runner.wp81.csproj
@@ -90,6 +90,14 @@
       <HintPath>..\..\..\packages\NUnit.3.0.1\lib\dotnet\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="PCLStorage, Version=1.0.2.0, Culture=neutral, PublicKeyToken=286fe515a2c35b64, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\PCLStorage.1.0.2\lib\portable-win8+wpa81\PCLStorage.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="PCLStorage.Abstractions, Version=1.0.2.0, Culture=neutral, PublicKeyToken=286fe515a2c35b64, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\PCLStorage.1.0.2\lib\portable-win8+wpa81\PCLStorage.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Xamarin.Forms.Core, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Xamarin.Forms.1.5.0.6447\lib\wpa81\Xamarin.Forms.Core.dll</HintPath>
       <Private>True</Private>

--- a/src/runner/nunit.runner.wp81/packages.config
+++ b/src/runner/nunit.runner.wp81/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="3.0.1" targetFramework="wpa81" />
+  <package id="PCLStorage" version="1.0.2" targetFramework="wpa81" />
   <package id="Xamarin.Forms" version="1.5.0.6447" targetFramework="wpa81" />
 </packages>

--- a/src/runner/nunit.runner/App.xaml.cs
+++ b/src/runner/nunit.runner/App.xaml.cs
@@ -21,6 +21,8 @@
 // ***********************************************************************
 
 using System.Reflection;
+
+using NUnit.Runner.Services;
 using NUnit.Runner.View;
 using NUnit.Runner.ViewModel;
 using Xamarin.Forms;
@@ -65,22 +67,12 @@ namespace NUnit.Runner
         }
 
         /// <summary>
-        /// If True, the tests will run automatically when the app starts
-        /// otherwise you must run them manually.
+        /// User options for the test suite.
         /// </summary>
-        public bool AutoRun
+        public TestOptions Options
         {
-            get { return _model.AutoRun; }
-            set { _model.AutoRun = value; }
-        }
-
-        /// <summary>
-        /// Creates a NUnit Xml result file on the host file system.
-        /// </summary>
-        public bool CreateXmlResultFile
-        {
-            get { return _model.CreateXmlResultFile; }
-            set { _model.CreateXmlResultFile = value; }
-        }
+            get { return _model.Options; }
+            set { _model.Options = value; }
+        }        
     }
 }

--- a/src/runner/nunit.runner/App.xaml.cs
+++ b/src/runner/nunit.runner/App.xaml.cs
@@ -73,5 +73,14 @@ namespace NUnit.Runner
             get { return _model.AutoRun; }
             set { _model.AutoRun = value; }
         }
+
+        /// <summary>
+        /// Creates a NUnit Xml result file on the host file system.
+        /// </summary>
+        public bool CreateXmlResultFile
+        {
+            get { return _model.CreateXmlResultFile; }
+            set { _model.CreateXmlResultFile = value; }
+        }
     }
 }

--- a/src/runner/nunit.runner/Messages/ErrorMessage.cs
+++ b/src/runner/nunit.runner/Messages/ErrorMessage.cs
@@ -1,0 +1,29 @@
+﻿
+
+namespace NUnit.Runner.Messages
+{
+    /// <summary>
+    /// Represents an error message
+    /// </summary>
+	public class ErrorMessage
+	{
+        /// <summary>
+        /// The name of this message
+        /// </summary>
+        public const string Name = nameof(ErrorMessage);
+
+        /// <summary>
+        /// Constructs an <see cref="ErrorMessage"/> with a message
+        /// </summary>
+        /// <param name="message"></param>
+        public ErrorMessage(string message)
+        {
+            Message = message;
+        }
+
+        /// <summary>
+        /// The error message
+        /// </summary>
+        public string Message { get; set; }
+    }
+}

--- a/src/runner/nunit.runner/Services/TcpWriter.cs
+++ b/src/runner/nunit.runner/Services/TcpWriter.cs
@@ -1,0 +1,108 @@
+﻿// ***********************************************************************
+// Copyright (c) 2008 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.IO;
+
+using System.Threading.Tasks;
+
+#if NETFX_CORE
+using Windows.Networking;
+using Windows.Networking.Sockets;
+#else
+using System.Net.Sockets;
+#endif
+
+namespace NUnit.Runner.Services
+{
+    /// <summary>
+    /// Redirects output to a Tcp connection
+    /// </summary>
+    class TcpWriter : TextWriter
+    {
+        private readonly string hostName;
+        private readonly int port;
+        
+        private StreamWriter writer;
+
+        public TcpWriter(string hostName, int port)
+        {
+            if (string.IsNullOrWhiteSpace(hostName))
+            {
+                throw new ArgumentNullException(nameof(hostName));
+            }
+
+            if ((port < 0) || (port > ushort.MaxValue))
+            {
+                throw new ArgumentException(nameof(port));
+            }
+
+            this.hostName = hostName;
+            this.port = port;
+        }
+
+        public async Task Connect()
+        {
+#if NETFX_CORE
+            var socket = new StreamSocket();
+            await
+                socket.ConnectAsync(new HostName(hostName), port.ToString())
+                      .AsTask()
+                      .ContinueWith(@object => writer = new StreamWriter(socket.OutputStream.AsStreamForWrite()));
+#else
+            TcpClient client;
+            NetworkStream stream;
+            await Task.Run(
+                () =>
+                {
+                    client = new TcpClient(hostName, port);
+                    stream = client.GetStream();
+                    this.writer = new StreamWriter(stream);
+                }).ConfigureAwait(false);
+#endif
+        }
+
+        public override void Write(char value)
+        {
+            writer.Write(value);
+        }
+
+        public override void Write(string value)
+        {
+            writer.Write(value);
+        }
+
+        public override void WriteLine(string value)
+        {
+            writer.WriteLine(value);
+            writer.Flush();
+        }
+
+        public override System.Text.Encoding Encoding => System.Text.Encoding.UTF8;
+
+        protected override void Dispose(bool disposing)
+        {
+            writer?.Dispose();
+        }
+    }
+}

--- a/src/runner/nunit.runner/Services/TcpWriterInfo.cs
+++ b/src/runner/nunit.runner/Services/TcpWriterInfo.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NUnit.Runner.Services
+{
+    public class TcpWriterInfo : IEquatable<TcpWriterInfo>
+    {
+        public TcpWriterInfo(string hostName, int port)
+        {
+            if (string.IsNullOrWhiteSpace(hostName))
+            {
+                throw new ArgumentNullException(nameof(hostName));
+            }
+
+            if ((port < 0) || (port > ushort.MaxValue))
+            {
+                throw new ArgumentException(nameof(port));
+            }
+
+            this.Hostname = hostName;
+            this.Port = port;
+        }
+
+        public string Hostname { get; set; }
+
+        public int Port { get; set; }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other"/> parameter; otherwise, false.
+        /// </returns>
+        /// <param name="other">An object to compare with this object.</param>
+        public bool Equals(TcpWriterInfo other)
+        {
+            return Hostname.Equals(other.Hostname, StringComparison.OrdinalIgnoreCase) && Port == other.Port;
+        }
+
+        public override string ToString()
+        {
+            return $"{Hostname}:{Port}";
+        }
+    }
+}

--- a/src/runner/nunit.runner/Services/TcpWriterInfo.cs
+++ b/src/runner/nunit.runner/Services/TcpWriterInfo.cs
@@ -1,30 +1,77 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
 
 namespace NUnit.Runner.Services
 {
+    /// <summary>
+    /// Represents the host and port to connect to
+    /// </summary>
     public class TcpWriterInfo : IEquatable<TcpWriterInfo>
     {
-        public TcpWriterInfo(string hostName, int port)
+        /// <summary>
+        /// Constructs a <see cref="TcpWriterInfo"/>
+        /// </summary>
+        /// <param name="hostName">The host name or IP to connect to</param>
+        /// <param name="port">The port to connect to</param>
+        /// <param name="timeout">The timeout in seconds</param>
+        public TcpWriterInfo(string hostName, int port, int timeout = 10)
         {
             if (string.IsNullOrWhiteSpace(hostName))
             {
                 throw new ArgumentNullException(nameof(hostName));
             }
 
-            if ((port < 0) || (port > ushort.MaxValue))
+            if ((port <= 0) || (port > ushort.MaxValue))
             {
-                throw new ArgumentException(nameof(port));
+                throw new ArgumentException("Must be between 1 and ushort.MaxValue", nameof(port));
             }
 
-            this.Hostname = hostName;
-            this.Port = port;
+            if (timeout <= 0)
+            {
+                throw new ArgumentException("Must be positive", nameof(timeout));
+            }
+
+            Hostname = hostName;
+            Port = port;
+            Timeout = timeout;
         }
 
+        /// <summary>
+        /// The host to connect to
+        /// </summary>
         public string Hostname { get; set; }
-
+        
+        /// <summary>
+        /// The port to connect to
+        /// </summary>
         public int Port { get; set; }
+
+        /// <summary>
+        /// The connect timeout in seconds
+        /// </summary>
+        public int Timeout { get; set; }
 
         /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.
@@ -33,14 +80,13 @@ namespace NUnit.Runner.Services
         /// true if the current object is equal to the <paramref name="other"/> parameter; otherwise, false.
         /// </returns>
         /// <param name="other">An object to compare with this object.</param>
-        public bool Equals(TcpWriterInfo other)
-        {
-            return Hostname.Equals(other.Hostname, StringComparison.OrdinalIgnoreCase) && Port == other.Port;
-        }
+        public bool Equals(TcpWriterInfo other) => 
+            Hostname.Equals(other.Hostname, StringComparison.OrdinalIgnoreCase) && Port == other.Port;
 
-        public override string ToString()
-        {
-            return $"{Hostname}:{Port}";
-        }
+        /// <summary>
+        /// Gets a string representation of the object
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString() => $"{Hostname}:{Port}";
     }
 }

--- a/src/runner/nunit.runner/Services/TcpWriterProcessor.cs
+++ b/src/runner/nunit.runner/Services/TcpWriterProcessor.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Runner.Services
+{
+    public class TcpWriterProcessor : TestResultProcessor
+    {
+        public TcpWriterProcessor(TestOptions options)
+            : base(options)
+        {
+        }
+
+        public override async Task Process(ITestResult testResult)
+        {
+            if (Options.TcpWriterParamaters != null)
+            {
+                try
+                {
+                    await WriteResult(testResult);
+                }
+                catch (Exception exception)
+                {
+                    string message = $"Fatal error while trying to send xml result by TCP to {Options.TcpWriterParamaters}\nDoes your server is running ?";
+                    throw new InvalidOperationException(message, exception);
+                }
+            }
+
+            if (Successor != null)
+            {
+                await Successor.Process(testResult);
+            }
+        }
+
+        private async Task WriteResult(ITestResult testResult)
+        {
+            using (var tcpWriter = new TcpWriter(Options.TcpWriterParamaters.Hostname, Options.TcpWriterParamaters.Port))
+            {
+                await tcpWriter.Connect().ConfigureAwait(false);
+                tcpWriter.Write(testResult.ToXml(true).OuterXml);
+            }
+        }
+    }
+}

--- a/src/runner/nunit.runner/Services/TcpWriterProcessor.cs
+++ b/src/runner/nunit.runner/Services/TcpWriterProcessor.cs
@@ -1,12 +1,36 @@
+// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
 using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 
 using NUnit.Framework.Interfaces;
+using Xamarin.Forms;
+using NUnit.Runner.Messages;
 
 namespace NUnit.Runner.Services
 {
-    public class TcpWriterProcessor : TestResultProcessor
+    class TcpWriterProcessor : TestResultProcessor
     {
         public TcpWriterProcessor(TestOptions options)
             : base(options)
@@ -15,7 +39,7 @@ namespace NUnit.Runner.Services
 
         public override async Task Process(ITestResult testResult)
         {
-            if (Options.TcpWriterParamaters != null)
+            if (Options.TcpWriterParameters != null)
             {
                 try
                 {
@@ -23,8 +47,8 @@ namespace NUnit.Runner.Services
                 }
                 catch (Exception exception)
                 {
-                    string message = $"Fatal error while trying to send xml result by TCP to {Options.TcpWriterParamaters}\nDoes your server is running ?";
-                    throw new InvalidOperationException(message, exception);
+                    string message = $"Fatal error while trying to send xml result by TCP to {Options.TcpWriterParameters}\n\n{exception.Message}\n\nIs your server running?";
+                    MessagingCenter.Send(new ErrorMessage(message), ErrorMessage.Name);
                 }
             }
 
@@ -36,7 +60,7 @@ namespace NUnit.Runner.Services
 
         private async Task WriteResult(ITestResult testResult)
         {
-            using (var tcpWriter = new TcpWriter(Options.TcpWriterParamaters.Hostname, Options.TcpWriterParamaters.Port))
+            using (var tcpWriter = new TcpWriter(Options.TcpWriterParameters))
             {
                 await tcpWriter.Connect().ConfigureAwait(false);
                 tcpWriter.Write(testResult.ToXml(true).OuterXml);

--- a/src/runner/nunit.runner/Services/TestOptions.cs
+++ b/src/runner/nunit.runner/Services/TestOptions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NUnit.Runner.Services
+{
+    /// <summary>
+    /// Options for the device test suite.
+    /// </summary>
+    public class TestOptions
+    {
+        /// <summary>
+        /// If True, the tests will run automatically when the app starts
+        /// otherwise you must run them manually.
+        /// </summary>
+        public bool AutoRun { get; set; }
+
+        /// <summary>
+        /// Information about the tcp listener host and port.
+        /// For now, send result as XML to the listening server.
+        /// </summary>
+        public TcpWriterInfo TcpWriterParamaters { get; set; }
+
+        /// <summary>
+        /// Creates a NUnit Xml result file on the host file system using PCLStorage library.
+        /// </summary>
+        public bool CreateXmlResultFile { get; set; }
+    }
+}

--- a/src/runner/nunit.runner/Services/TestOptions.cs
+++ b/src/runner/nunit.runner/Services/TestOptions.cs
@@ -1,6 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
 
 namespace NUnit.Runner.Services
 {
@@ -19,7 +38,7 @@ namespace NUnit.Runner.Services
         /// Information about the tcp listener host and port.
         /// For now, send result as XML to the listening server.
         /// </summary>
-        public TcpWriterInfo TcpWriterParamaters { get; set; }
+        public TcpWriterInfo TcpWriterParameters { get; set; }
 
         /// <summary>
         /// Creates a NUnit Xml result file on the host file system using PCLStorage library.

--- a/src/runner/nunit.runner/Services/TestResultProcessor.cs
+++ b/src/runner/nunit.runner/Services/TestResultProcessor.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Runner.Services
+{
+    public abstract class TestResultProcessor
+    {
+        protected TestResultProcessor(TestOptions options)
+        {
+            Options = options;
+        }
+
+        protected TestOptions Options { get; private set; }
+
+        public TestResultProcessor Successor { get; set; }
+
+        public abstract Task Process(ITestResult testResult);
+
+        public static TestResultProcessor BuildChainOfResponsability(TestOptions options)
+        {
+            var tcpWriter = new TcpWriterProcessor(options);
+            var xmlFileWriter = new XmlFileProcessor(options);
+
+            tcpWriter.Successor = xmlFileWriter;
+            return tcpWriter;
+        }
+    }
+}

--- a/src/runner/nunit.runner/Services/TestResultProcessor.cs
+++ b/src/runner/nunit.runner/Services/TestResultProcessor.cs
@@ -1,12 +1,33 @@
-﻿using System.Collections.Generic;
-using System.Text;
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
 using System.Threading.Tasks;
 
 using NUnit.Framework.Interfaces;
 
 namespace NUnit.Runner.Services
 {
-    public abstract class TestResultProcessor
+    abstract class TestResultProcessor
     {
         protected TestResultProcessor(TestOptions options)
         {

--- a/src/runner/nunit.runner/Services/XmlFileProcessor.cs
+++ b/src/runner/nunit.runner/Services/XmlFileProcessor.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+
+using NUnit.Framework.Interfaces;
+
+using PCLStorage;
+
+using FileAccess = PCLStorage.FileAccess;
+
+namespace NUnit.Runner.Services
+{
+    public class XmlFileProcessor : TestResultProcessor
+    {
+        public XmlFileProcessor(TestOptions options)
+            : base(options)
+        {
+        }
+
+        public override async Task Process(ITestResult testResult)
+        {
+            if (Options.CreateXmlResultFile)
+            {
+                try
+                {
+                    await WriteXmlResultFile(testResult).ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    Debug.WriteLine("Fatal error while trying to write xml result file!");
+                    throw;
+                }
+            }
+
+            if (Successor != null)
+            {
+                await Successor.Process(testResult).ConfigureAwait(false);
+            }
+        }
+
+        private async Task WriteXmlResultFile(ITestResult testResult)
+        {
+            const string OutputFolderName = "NUnitTestsOutput";
+            const string OutputXmlReportName = "nunit_result.xml";
+            var localStorageFolder = FileSystem.Current.LocalStorage;
+
+            var existResult = await localStorageFolder.CheckExistsAsync(OutputFolderName);
+            if (existResult == ExistenceCheckResult.FileExists)
+            {
+                var existingFile = await localStorageFolder.GetFileAsync(OutputFolderName);
+                await existingFile.DeleteAsync();
+            }
+
+            var outputFolder = await localStorageFolder.CreateFolderAsync(OutputFolderName, CreationCollisionOption.OpenIfExists);
+            IFile xmlResultFile = await outputFolder.CreateFileAsync(OutputXmlReportName, CreationCollisionOption.ReplaceExisting);
+            using (var resultFileStream = new StreamWriter(await xmlResultFile.OpenAsync(FileAccess.ReadAndWrite)))
+            {
+                string xmlString = testResult.ToXml(true).OuterXml;
+                await resultFileStream.WriteAsync(xmlString);
+            }
+        }
+    }
+}

--- a/src/runner/nunit.runner/Services/XmlFileProcessor.cs
+++ b/src/runner/nunit.runner/Services/XmlFileProcessor.cs
@@ -1,3 +1,26 @@
+// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -11,7 +34,7 @@ using FileAccess = PCLStorage.FileAccess;
 
 namespace NUnit.Runner.Services
 {
-    public class XmlFileProcessor : TestResultProcessor
+    class XmlFileProcessor : TestResultProcessor
     {
         public XmlFileProcessor(TestOptions options)
             : base(options)
@@ -39,10 +62,10 @@ namespace NUnit.Runner.Services
             }
         }
 
-        private async Task WriteXmlResultFile(ITestResult testResult)
+        async Task WriteXmlResultFile(ITestResult testResult)
         {
-            const string OutputFolderName = "NUnitTestsOutput";
-            const string OutputXmlReportName = "nunit_result.xml";
+            const string OutputFolderName = "NUnitTestOutput";
+            const string OutputXmlReportName = "TestResults.xml";
             var localStorageFolder = FileSystem.Current.LocalStorage;
 
             var existResult = await localStorageFolder.CheckExistsAsync(OutputFolderName);

--- a/src/runner/nunit.runner/View/SummaryView.xaml.cs
+++ b/src/runner/nunit.runner/View/SummaryView.xaml.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using NUnit.Runner.Messages;
 using NUnit.Runner.ViewModel;
 using Xamarin.Forms;
 
@@ -39,7 +40,11 @@ namespace NUnit.Runner.View
 		    _model.Navigation = Navigation;
 		    BindingContext = _model;
 			InitializeComponent();
-		}
+
+            MessagingCenter.Subscribe<ErrorMessage>(this, ErrorMessage.Name, error => {
+                Device.BeginInvokeOnMainThread(async () => await DisplayAlert("Error", error.Message, "OK"));
+            });
+        }
 
         /// <summary>
         /// Called when the view is appearing

--- a/src/runner/nunit.runner/nunit.runner.projitems
+++ b/src/runner/nunit.runner/nunit.runner.projitems
@@ -16,6 +16,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\XamarinExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Properties\Annotations.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Properties\AssemblyCommon.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\TcpWriterInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\TcpWriterProcessor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\TestResultProcessor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\TcpWriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\TestOptions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\XmlFileProcessor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModel\BaseViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModel\ResultSummary.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModel\ResultsViewModel.cs" />

--- a/src/runner/nunit.runner/nunit.runner.projitems
+++ b/src/runner/nunit.runner/nunit.runner.projitems
@@ -14,6 +14,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\XamarinExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Messages\ErrorMessage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Properties\Annotations.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Properties\AssemblyCommon.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\TcpWriterInfo.cs" />

--- a/src/tests/nunit.runner.tests.Droid/MainActivity.cs
+++ b/src/tests/nunit.runner.tests.Droid/MainActivity.cs
@@ -46,18 +46,18 @@ namespace NUnit.Runner.Tests
 
             // Available options for testing
             nunit.Options = new TestOptions
-                {
-                    // If True, the tests will run automatically when the app starts
-                    // otherwise you must run them manually.
-                    AutoRun = true,
+            {
+                // If True, the tests will run automatically when the app starts
+                // otherwise you must run them manually.
+                AutoRun = true,
 
-                    // Information about the tcp listener host and port.
-                    // For now, send result as XML to the listening server.
-                    // TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000),
+                // Information about the tcp listener host and port.
+                // For now, send result as XML to the listening server.
+                //TcpWriterParameters = new TcpWriterInfo("192.168.0.108", 13000),
 
-                    // Creates a NUnit Xml result file on the host file system using PCLStorage library.
-                    CreateXmlResultFile = false
-                };
+                // Creates a NUnit Xml result file on the host file system using PCLStorage library.
+                CreateXmlResultFile = true
+            };
             
             LoadApplication(nunit);
         }

--- a/src/tests/nunit.runner.tests.Droid/MainActivity.cs
+++ b/src/tests/nunit.runner.tests.Droid/MainActivity.cs
@@ -44,12 +44,21 @@ namespace NUnit.Runner.Tests
             // If you want to add tests in another assembly
             //nunit.AddTestAssembly(typeof(MyTests).Assembly);
 
-            // Do you want to automatically run tests when the app starts?
-            nunit.Options = new TestOptions { AutoRun = true };
+            // Available options for testing
+            nunit.Options = new TestOptions
+                {
+                    // If True, the tests will run automatically when the app starts
+                    // otherwise you must run them manually.
+                    AutoRun = true,
 
-            // Available options so far
-            //nunit.Options = new TestOptions { AutoRun = true, TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000), CreateXmlResultFile = true };
+                    // Information about the tcp listener host and port.
+                    // For now, send result as XML to the listening server.
+                    // TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000),
 
+                    // Creates a NUnit Xml result file on the host file system using PCLStorage library.
+                    CreateXmlResultFile = false
+                };
+            
             LoadApplication(nunit);
         }
     }

--- a/src/tests/nunit.runner.tests.Droid/MainActivity.cs
+++ b/src/tests/nunit.runner.tests.Droid/MainActivity.cs
@@ -25,6 +25,8 @@ using Android.App;
 using Android.Content.PM;
 using Android.OS;
 
+using NUnit.Runner.Services;
+
 namespace NUnit.Runner.Tests
 {
     [Activity(Label = "nunit.runner", Icon = "@drawable/icon", Theme= "@android:style/Theme.Holo.Light", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
@@ -43,9 +45,10 @@ namespace NUnit.Runner.Tests
             //nunit.AddTestAssembly(typeof(MyTests).Assembly);
 
             // Do you want to automatically run tests when the app starts?
-            nunit.AutoRun = true;
+            nunit.Options = new TestOptions { AutoRun = true };
 
-            nunit.CreateXmlResultFile = true;
+            // Available options so far
+            //nunit.Options = new TestOptions { AutoRun = true, TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000), CreateXmlResultFile = true };
 
             LoadApplication(nunit);
         }

--- a/src/tests/nunit.runner.tests.Droid/MainActivity.cs
+++ b/src/tests/nunit.runner.tests.Droid/MainActivity.cs
@@ -45,6 +45,8 @@ namespace NUnit.Runner.Tests
             // Do you want to automatically run tests when the app starts?
             nunit.AutoRun = true;
 
+            nunit.CreateXmlResultFile = true;
+
             LoadApplication(nunit);
         }
     }

--- a/src/tests/nunit.runner.tests.iOS/AppDelegate.cs
+++ b/src/tests/nunit.runner.tests.iOS/AppDelegate.cs
@@ -52,11 +52,20 @@ namespace NUnit.Runner.Tests
             // If you want to add tests in another assembly
             //nunit.AddTestAssembly(typeof(MyTests).Assembly);
 
-            // Do you want to automatically run tests when the app starts?
-            nunit.Options = new TestOptions { AutoRun = true };
+            // Available options for testing
+            nunit.Options = new TestOptions
+            {
+                // If True, the tests will run automatically when the app starts
+                // otherwise you must run them manually.
+                AutoRun = true,
 
-            // Available options so far
-            // nunit.Options = new TestOptions { AutoRun = true, TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000), CreateXmlResultFile = true };
+                // Information about the tcp listener host and port.
+                // For now, send result as XML to the listening server.
+                // TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000),
+
+                // Creates a NUnit Xml result file on the host file system using PCLStorage library.
+                CreateXmlResultFile = false
+            };
 
             LoadApplication(nunit);
 

--- a/src/tests/nunit.runner.tests.iOS/AppDelegate.cs
+++ b/src/tests/nunit.runner.tests.iOS/AppDelegate.cs
@@ -22,6 +22,9 @@
 // ***********************************************************************
 
 using Foundation;
+
+using NUnit.Runner.Services;
+
 using UIKit;
 
 namespace NUnit.Runner.Tests
@@ -50,7 +53,10 @@ namespace NUnit.Runner.Tests
             //nunit.AddTestAssembly(typeof(MyTests).Assembly);
 
             // Do you want to automatically run tests when the app starts?
-            nunit.AutoRun = true;
+            nunit.Options = new TestOptions { AutoRun = true };
+
+            // Available options so far
+            // nunit.Options = new TestOptions { AutoRun = true, TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000), CreateXmlResultFile = true };
 
             LoadApplication(nunit);
 

--- a/src/tests/nunit.runner.tests.iOS/AppDelegate.cs
+++ b/src/tests/nunit.runner.tests.iOS/AppDelegate.cs
@@ -61,7 +61,7 @@ namespace NUnit.Runner.Tests
 
                 // Information about the tcp listener host and port.
                 // For now, send result as XML to the listening server.
-                // TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000),
+                //TcpWriterParameters = new TcpWriterInfo("192.168.0.108", 13000),
 
                 // Creates a NUnit Xml result file on the host file system using PCLStorage library.
                 CreateXmlResultFile = false

--- a/src/tests/nunit.runner.tests.uwp/MainPage.xaml.cs
+++ b/src/tests/nunit.runner.tests.uwp/MainPage.xaml.cs
@@ -22,6 +22,8 @@
 
 using System.Reflection;
 
+using NUnit.Runner.Services;
+
 namespace NUnit.Runner.Tests
 {
     public sealed partial class MainPage
@@ -39,7 +41,10 @@ namespace NUnit.Runner.Tests
             nunit.AddTestAssembly(typeof(MainPage).GetTypeInfo().Assembly);
 
             // Do you want to automatically run tests when the app starts?
-            nunit.AutoRun = true;
+            nunit.Options = new TestOptions { AutoRun = true };
+
+            // Available options so far
+            // nunit.Options = new TestOptions { AutoRun = true, TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000), CreateXmlResultFile = true };
 
             LoadApplication(nunit);
         }

--- a/src/tests/nunit.runner.tests.uwp/MainPage.xaml.cs
+++ b/src/tests/nunit.runner.tests.uwp/MainPage.xaml.cs
@@ -49,7 +49,8 @@ namespace NUnit.Runner.Tests
 
                 // Information about the tcp listener host and port.
                 // For now, send result as XML to the listening server.
-                // TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000),
+                // NOTE: Your UWP App must have Private Networks capability enabled
+                //TcpWriterParameters = new TcpWriterInfo("192.168.0.108", 13000),
 
                 // Creates a NUnit Xml result file on the host file system using PCLStorage library.
                 CreateXmlResultFile = false

--- a/src/tests/nunit.runner.tests.uwp/MainPage.xaml.cs
+++ b/src/tests/nunit.runner.tests.uwp/MainPage.xaml.cs
@@ -40,12 +40,21 @@ namespace NUnit.Runner.Tests
             // duplicate the following line with a type from the referenced assembly
             nunit.AddTestAssembly(typeof(MainPage).GetTypeInfo().Assembly);
 
-            // Do you want to automatically run tests when the app starts?
-            nunit.Options = new TestOptions { AutoRun = true };
+            // Available options for testing
+            nunit.Options = new TestOptions
+            {
+                // If True, the tests will run automatically when the app starts
+                // otherwise you must run them manually.
+                AutoRun = true,
 
-            // Available options so far
-            // nunit.Options = new TestOptions { AutoRun = true, TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000), CreateXmlResultFile = true };
+                // Information about the tcp listener host and port.
+                // For now, send result as XML to the listening server.
+                // TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000),
 
+                // Creates a NUnit Xml result file on the host file system using PCLStorage library.
+                CreateXmlResultFile = false
+            };
+            
             LoadApplication(nunit);
         }
     }

--- a/src/tests/nunit.runner.tests.uwp/Package.appxmanifest
+++ b/src/tests/nunit.runner.tests.uwp/Package.appxmanifest
@@ -1,49 +1,29 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
-<Package
-  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
-  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
-  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-  IgnorableNamespaces="uap mp">
-
-  <Identity
-    Name="b4d9fd97-b889-4078-90b0-c76cd1b46dde"
-    Publisher="CN=Rob"
-    Version="1.0.0.0" />
-
-  <mp:PhoneIdentity PhoneProductId="b4d9fd97-b889-4078-90b0-c76cd1b46dde" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
-
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
+  <Identity Name="b4d9fd97-b889-4078-90b0-c76cd1b46dde" Publisher="CN=Rob" Version="1.0.0.0" />
+  <mp:PhoneIdentity PhoneProductId="b4d9fd97-b889-4078-90b0-c76cd1b46dde" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>nunit.runner.tests.uwp</DisplayName>
     <PublisherDisplayName>Rob</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
-
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
   </Dependencies>
-
   <Resources>
-    <Resource Language="x-generate"/>
+    <Resource Language="x-generate" />
   </Resources>
-
   <Applications>
-    <Application Id="App"
-      Executable="$targetnametoken$.exe"
-      EntryPoint="nunit.runner.tests.uwp.App">
-      <uap:VisualElements
-        DisplayName="nunit.runner.tests.uwp"
-        Square150x150Logo="Assets\Square150x150Logo.png"
-        Square44x44Logo="Assets\Square44x44Logo.png"
-        Description="nunit.runner.tests.uwp"
-        BackgroundColor="transparent">
-        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png"/>
+    <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="nunit.runner.tests.uwp.App">
+      <uap:VisualElements DisplayName="nunit.runner.tests.uwp" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" Description="nunit.runner.tests.uwp" BackgroundColor="transparent">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png">
+        </uap:DefaultTile>
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
     </Application>
   </Applications>
-
   <Capabilities>
     <Capability Name="internetClient" />
+    <Capability Name="privateNetworkClientServer" />
   </Capabilities>
 </Package>

--- a/src/tests/nunit.runner.tests.uwp/project.lock.json
+++ b/src/tests/nunit.runner.tests.uwp/project.lock.json
@@ -240,6 +240,16 @@
           "lib/dotnet/nunit.framework.dll": {}
         }
       },
+      "PCLStorage/1.0.2": {
+        "compile": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        },
+        "runtime": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        }
+      },
       "System.AppContext/4.0.0": {
         "dependencies": {
           "System.Collections": "[4.0.0, )",
@@ -1871,6 +1881,16 @@
         },
         "runtime": {
           "lib/dotnet/nunit.framework.dll": {}
+        }
+      },
+      "PCLStorage/1.0.2": {
+        "compile": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        },
+        "runtime": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
         }
       },
       "System.AppContext/4.0.0": {
@@ -3537,6 +3557,16 @@
         },
         "runtime": {
           "lib/dotnet/nunit.framework.dll": {}
+        }
+      },
+      "PCLStorage/1.0.2": {
+        "compile": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        },
+        "runtime": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
         }
       },
       "System.AppContext/4.0.0": {
@@ -5210,6 +5240,16 @@
           "lib/dotnet/nunit.framework.dll": {}
         }
       },
+      "PCLStorage/1.0.2": {
+        "compile": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        },
+        "runtime": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        }
+      },
       "System.AppContext/4.0.0": {
         "dependencies": {
           "System.Collections": "[4.0.0, )",
@@ -6874,6 +6914,16 @@
         },
         "runtime": {
           "lib/dotnet/nunit.framework.dll": {}
+        }
+      },
+      "PCLStorage/1.0.2": {
+        "compile": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        },
+        "runtime": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
         }
       },
       "System.AppContext/4.0.0": {
@@ -8547,6 +8597,16 @@
           "lib/dotnet/nunit.framework.dll": {}
         }
       },
+      "PCLStorage/1.0.2": {
+        "compile": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        },
+        "runtime": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        }
+      },
       "System.AppContext/4.0.0": {
         "dependencies": {
           "System.Collections": "[4.0.0, )",
@@ -10213,6 +10273,16 @@
           "lib/dotnet/nunit.framework.dll": {}
         }
       },
+      "PCLStorage/1.0.2": {
+        "compile": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        },
+        "runtime": {
+          "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll": {},
+          "lib/portable-win8+wpa81/PCLStorage.dll": {}
+        }
+      },
       "System.AppContext/4.0.0": {
         "dependencies": {
           "System.Collections": "[4.0.0, )",
@@ -11635,7 +11705,7 @@
       ]
     },
     "Microsoft.ApplicationInsights.WindowsApps/1.0.0": {
-      "sha512": "fNCAjIwvbTV+G0dT14bgM5tptsqeSaKQaCrlq7QknOq1Xdm8ZmgsDYddMgXkvykyKLjWyU6fKuOpj6fsQJy+wQ==",
+      "sha512": "NvBQnFeiFd0O1QdBz06UGApD7zn7ztVi7qO18IsM3EjiXRNgfrEBXB+azNm8XqLY8xGFAqh3HAuSd/wHZMe0XA==",
       "type": "Package",
       "files": [
         "[Content_Types].xml",
@@ -12324,6 +12394,52 @@
         "NOTICES.txt",
         "NUnit.nuspec",
         "package/services/metadata/core-properties/59ec910f17c54b6493a6276f36784454.psmdcp"
+      ]
+    },
+    "PCLStorage/1.0.2": {
+      "sha512": "9If+1ZFCk3QaT/asfiL+J9FMnx2CTMrLCU8tDMUOI/aCGWGWl9vJ1/KcMkjf92op23ZknenvYJZBLDAqE3sFlg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/monoandroid/PCLStorage.Abstractions.dll",
+        "lib/monoandroid/PCLStorage.Abstractions.xml",
+        "lib/monoandroid/PCLStorage.dll",
+        "lib/monoandroid/PCLStorage.xml",
+        "lib/monotouch/PCLStorage.Abstractions.dll",
+        "lib/monotouch/PCLStorage.Abstractions.xml",
+        "lib/monotouch/PCLStorage.dll",
+        "lib/monotouch/PCLStorage.xml",
+        "lib/net45/PCLStorage.Abstractions.dll",
+        "lib/net45/PCLStorage.Abstractions.xml",
+        "lib/net45/PCLStorage.dll",
+        "lib/net45/PCLStorage.xml",
+        "lib/portable-net45+sl5+wp8+wpa81+win8+monoandroid+monotouch+Xamarin.iOS+Xamarin.Mac/PCLStorage.Abstractions.dll",
+        "lib/portable-net45+sl5+wp8+wpa81+win8+monoandroid+monotouch+Xamarin.iOS+Xamarin.Mac/PCLStorage.Abstractions.xml",
+        "lib/portable-net45+sl5+wp8+wpa81+win8+monoandroid+monotouch+Xamarin.iOS+Xamarin.Mac/PCLStorage.dll",
+        "lib/portable-net45+sl5+wp8+wpa81+win8+monoandroid+monotouch+Xamarin.iOS+Xamarin.Mac/PCLStorage.xml",
+        "lib/portable-net45+wp8+wpa81+win8+monoandroid+monotouch+Xamarin.iOS+Xamarin.Mac/PCLStorage.Abstractions.dll",
+        "lib/portable-net45+wp8+wpa81+win8+monoandroid+monotouch+Xamarin.iOS+Xamarin.Mac/PCLStorage.Abstractions.xml",
+        "lib/portable-net45+wp8+wpa81+win8+monoandroid+monotouch+Xamarin.iOS+Xamarin.Mac/PCLStorage.dll",
+        "lib/portable-net45+wp8+wpa81+win8+monoandroid+monotouch+Xamarin.iOS+Xamarin.Mac/PCLStorage.xml",
+        "lib/portable-win8+wpa81/PCLStorage.Abstractions.dll",
+        "lib/portable-win8+wpa81/PCLStorage.Abstractions.xml",
+        "lib/portable-win8+wpa81/PCLStorage.dll",
+        "lib/portable-win8+wpa81/PCLStorage.xml",
+        "lib/portable-Xamarin.iOS+Xamarin.Mac/PCLStorage.Abstractions.dll",
+        "lib/portable-Xamarin.iOS+Xamarin.Mac/PCLStorage.Abstractions.xml",
+        "lib/portable-Xamarin.iOS+Xamarin.Mac/PCLStorage.dll",
+        "lib/portable-Xamarin.iOS+Xamarin.Mac/PCLStorage.xml",
+        "lib/sl5/PCLStorage.Abstractions.dll",
+        "lib/sl5/PCLStorage.Abstractions.xml",
+        "lib/sl5/PCLStorage.dll",
+        "lib/sl5/PCLStorage.xml",
+        "lib/wp8/PCLStorage.Abstractions.dll",
+        "lib/wp8/PCLStorage.Abstractions.xml",
+        "lib/wp8/PCLStorage.dll",
+        "lib/wp8/PCLStorage.xml",
+        "package/services/metadata/core-properties/dba2944eebe04ff298a58a04f2282910.psmdcp",
+        "PCLStorage.nuspec"
       ]
     },
     "System.AppContext/4.0.0": {

--- a/src/tests/nunit.runner.tests.uwp/project.lock.json
+++ b/src/tests/nunit.runner.tests.uwp/project.lock.json
@@ -11705,7 +11705,7 @@
       ]
     },
     "Microsoft.ApplicationInsights.WindowsApps/1.0.0": {
-      "sha512": "NvBQnFeiFd0O1QdBz06UGApD7zn7ztVi7qO18IsM3EjiXRNgfrEBXB+azNm8XqLY8xGFAqh3HAuSd/wHZMe0XA==",
+      "sha512": "fNCAjIwvbTV+G0dT14bgM5tptsqeSaKQaCrlq7QknOq1Xdm8ZmgsDYddMgXkvykyKLjWyU6fKuOpj6fsQJy+wQ==",
       "type": "Package",
       "files": [
         "[Content_Types].xml",
@@ -15138,7 +15138,7 @@
       ]
     },
     "Xamarin.Forms/1.5.0.6447": {
-      "sha512": "iPmiog6UF5ZZNyE0faRdWhGlVaoqVRi193wyeStwRxX6l3QNomMFBaHN58ly2vOuKD2KYk+McjBOEQi6HfNwEA==",
+      "sha512": "0oBfhFmKt4kxFK+iBdTtZaW6Ys/adM7fH/47EcHLXfsNoe34xtYAqEZ7A4lGMnzg/5hgRVHmiOV2Z0cmZvuTwg==",
       "type": "Package",
       "files": [
         "[Content_Types].xml",

--- a/src/tests/nunit.runner.tests.wp81/MainPage.xaml.cs
+++ b/src/tests/nunit.runner.tests.wp81/MainPage.xaml.cs
@@ -41,11 +41,20 @@ namespace NUnit.Runner.Tests
             // duplicate the following line with a type from the referenced assembly
             nunit.AddTestAssembly(typeof(MainPage).GetTypeInfo().Assembly);
 
-            // Do you want to automatically run tests when the app starts?
-            nunit.Options = new TestOptions { AutoRun = true };
+            // Available options for testing
+            nunit.Options = new TestOptions
+            {
+                // If True, the tests will run automatically when the app starts
+                // otherwise you must run them manually.
+                AutoRun = true,
 
-            // Available options so far
-            // nunit.Options = new TestOptions { AutoRun = true, TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000), CreateXmlResultFile = true };
+                // Information about the tcp listener host and port.
+                // For now, send result as XML to the listening server.
+                // TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000),
+
+                // Creates a NUnit Xml result file on the host file system using PCLStorage library.
+                CreateXmlResultFile = false
+            };
 
             LoadApplication(nunit);
 

--- a/src/tests/nunit.runner.tests.wp81/MainPage.xaml.cs
+++ b/src/tests/nunit.runner.tests.wp81/MainPage.xaml.cs
@@ -23,6 +23,8 @@
 using System.Reflection;
 using Windows.UI.Xaml.Navigation;
 
+using NUnit.Runner.Services;
+
 namespace NUnit.Runner.Tests
 {
     public sealed partial class MainPage
@@ -40,7 +42,10 @@ namespace NUnit.Runner.Tests
             nunit.AddTestAssembly(typeof(MainPage).GetTypeInfo().Assembly);
 
             // Do you want to automatically run tests when the app starts?
-            nunit.AutoRun = true;
+            nunit.Options = new TestOptions { AutoRun = true };
+
+            // Available options so far
+            // nunit.Options = new TestOptions { AutoRun = true, TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000), CreateXmlResultFile = true };
 
             LoadApplication(nunit);
 

--- a/src/tests/nunit.runner.tests.wp81/MainPage.xaml.cs
+++ b/src/tests/nunit.runner.tests.wp81/MainPage.xaml.cs
@@ -50,7 +50,7 @@ namespace NUnit.Runner.Tests
 
                 // Information about the tcp listener host and port.
                 // For now, send result as XML to the listening server.
-                // TcpWriterParamaters = new TcpWriterInfo("10.0.2.2", 13000),
+                //TcpWriterParameters = new TcpWriterInfo("192.168.0.108", 13000),
 
                 // Creates a NUnit Xml result file on the host file system using PCLStorage library.
                 CreateXmlResultFile = false


### PR DESCRIPTION
Fixes #17: Options.TcpWriterParameters
For now tcp writer sends the xml report back to the listening server.

Fixes #24: Options.CreateXmlResultFile
The xml result is saved in the app data folder (usage of FileSystem.Current.LocalStorage of PCLStorage).

Additional work added to PR #50 by @roubachof. I added a timeout, cleaned up a bit of code to coding standards and report errors to a dialog rather than crashing with an uncaught exception.