### PR TITLE
Show running tests

### DIFF
--- a/src/runner/nunit.runner/Extensions/XamarinExtensions.cs
+++ b/src/runner/nunit.runner/Extensions/XamarinExtensions.cs
@@ -12,6 +12,7 @@ namespace NUnit.Runner.Extensions
         /// <returns></returns>
         public static Color Color(this ITestResult result)
         {
+			if (result == null) return Xamarin.Forms.Color.White;
             switch (result.ResultState.Status)
             {
                 case TestStatus.Passed:

--- a/src/runner/nunit.runner/View/SummaryView.xaml
+++ b/src/runner/nunit.runner/View/SummaryView.xaml
@@ -1,133 +1,150 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="NUnit.Runner.View.SummaryView"
-             Title="NUnit 3"
-             Padding="10"
-             BackgroundColor="{DynamicResource defaultBackground}" >
-    <ContentPage.Triggers>
-        <DataTrigger TargetType="ContentPage" Binding="{Binding Running}" Value="True">
-            <Setter Property="IsBusy" Value="True" />
-        </DataTrigger>
-    </ContentPage.Triggers>
-    <StackLayout Orientation="Vertical" Spacing="4" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" BackgroundColor="{DynamicResource defaultBackground}">
-        <Button Text="Run Tests" Command="{Binding RunTestsCommand}"  HorizontalOptions="FillAndExpand">
-            <Button.Triggers>
-                <DataTrigger TargetType="Button" Binding="{Binding Running}" Value="True">
-                    <Setter Property="IsEnabled" Value="False" />
-                </DataTrigger>
-            </Button.Triggers>
-        </Button>
-
-        <ScrollView Orientation="Vertical"
-                    VerticalOptions="FillAndExpand" 
-                    HorizontalOptions="FillAndExpand"
-                    BackgroundColor="#F2F2F2">
-
-            <Grid HorizontalOptions="FillAndExpand" RowSpacing="0" Padding="10" BackgroundColor="White">
-                <Grid.Triggers>
-                    <DataTrigger TargetType="Grid" Binding="{Binding HasResults}" Value="False">
-                        <Setter Property="IsVisible" Value="False" />
-                    </DataTrigger>
-                </Grid.Triggers>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition />
-                    <ColumnDefinition />
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <!-- Rows with height of 10 are just for spacing between sections -->
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="10" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="10" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="10" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-                
-                <StackLayout Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"  Orientation="Horizontal" Spacing="4" HorizontalOptions="CenterAndExpand">
-                    <Label Text="Overall result:" TextColor="{Binding Results.OverallResultColor}" FontAttributes="Bold" FontSize="Large"/>
-                    <Label Text="{Binding Results.OverallResult}" TextColor="{Binding Results.OverallResultColor}" FontAttributes="Bold" FontSize="Large" />
-                </StackLayout>
-
-                <StackLayout Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="4">
-                    <Label Text="Tests run:" FontSize="Large" FontAttributes="Bold" />
-                    <Label Text="{Binding Results.RunCount}" FontSize="Large" />
-                </StackLayout>
-
-                <StackLayout Grid.Row="3" Grid.Column="0" Orientation="Horizontal" Spacing="4">
-                    <Label Text="  Passed:" FontSize="Medium" FontAttributes="Bold" />
-                    <Label Text="{Binding Results.PassCount}" FontSize="Medium" />
-                </StackLayout>
-                <StackLayout Grid.Row="3" Grid.Column="1" Orientation="Horizontal" Spacing="4">
-                    <Label Text="  Errors:" FontSize="Medium" FontAttributes="Bold" />
-                    <Label Text="{Binding Results.ErrorCount}" FontSize="Medium" />
-                </StackLayout>
-                <StackLayout Grid.Row="4" Grid.Column="0" Orientation="Horizontal" Spacing="4">
-                    <Label Text="  Inconclusive:" FontSize="Medium" FontAttributes="Bold" />
-                    <Label Text="{Binding Results.InconclusiveCount}" FontSize="Medium" />
-                </StackLayout>
-                <StackLayout Grid.Row="4" Grid.Column="1" Orientation="Horizontal" Spacing="4">
-                    <Label Text="  Failures:" FontSize="Medium" FontAttributes="Bold" />
-                    <Label Text="{Binding Results.FailureCount}" FontSize="Medium" />
-                </StackLayout>
-
-                <StackLayout Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="4">
-                    <Label Text="Not run:" FontSize="Large" FontAttributes="Bold" />
-                    <Label Text="{Binding Results.NotRunCount}" FontSize="Large" />
-                </StackLayout>
-                <StackLayout Grid.Row="7" Grid.Column="0" Orientation="Horizontal" Spacing="4">
-                    <Label Text="  Ignored:" FontSize="Medium" FontAttributes="Bold" />
-                    <Label Text="{Binding Results.IgnoreCount}" FontSize="Medium" />
-                </StackLayout>
-                <StackLayout Grid.Row="7" Grid.Column="1" Orientation="Horizontal" Spacing="4">
-                    <Label Text="  Explicit:" FontSize="Medium" FontAttributes="Bold" />
-                    <Label Text="{Binding Results.ExplicitCount}" FontSize="Medium" />
-                </StackLayout>
-                <StackLayout Grid.Row="8" Grid.Column="0" Orientation="Horizontal" Spacing="4">
-                    <Label Text="  Skipped:" FontSize="Medium" FontAttributes="Bold" />
-                    <Label Text="{Binding Results.SkipCount}" FontSize="Medium" />
-                </StackLayout>
-                <StackLayout Grid.Row="8" Grid.Column="1" Orientation="Horizontal" Spacing="4">
-                    <Label Text="  Invalid:" FontSize="Medium" FontAttributes="Bold" />
-                    <Label Text="{Binding Results.InvalidCount}" FontSize="Medium" />
-                </StackLayout>
-
-                <StackLayout Grid.Row="10" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="4">
-                    <Label Text="Start time:" FontSize="Small" FontAttributes="Bold" />
-                    <Label Text="{Binding Results.TestResult.StartTime, StringFormat='{0:u}'}" FontSize="Small" />
-                </StackLayout>
-                <StackLayout Grid.Row="11" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="4">
-                    <Label Text="End time:" FontSize="Small" FontAttributes="Bold" />
-                    <Label Text="{Binding Results.TestResult.EndTime, StringFormat='{0:u}'}" FontSize="Small" />
-                </StackLayout>
-                <StackLayout Grid.Row="12" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="4">
-                    <Label Text="Duration:" FontSize="Small" FontAttributes="Bold" />
-                    <Label Text="{Binding Results.TestResult.Duration, StringFormat='{0:F3} seconds'}" FontSize="Small" />
-                </StackLayout>
-            </Grid>
-
-        </ScrollView>
-
-        <Button Text="All Results" Command="{Binding ViewAllResultsCommand}" HorizontalOptions="FillAndExpand" VerticalOptions="End" >
-            <Button.Triggers>
-                <DataTrigger TargetType="Button" Binding="{Binding HasResults}" Value="False">
-                    <Setter Property="IsEnabled" Value="False" />
-                </DataTrigger>
-            </Button.Triggers>
-        </Button>
-        <Button Text="Failed Results" Command="{Binding ViewFailedResultsCommand}" HorizontalOptions="FillAndExpand" VerticalOptions="End" >
-            <Button.Triggers>
-                <DataTrigger TargetType="Button" Binding="{Binding HasResults}" Value="False">
-                    <Setter Property="IsEnabled" Value="False" />
-                </DataTrigger>
-            </Button.Triggers>
-        </Button>
-    </StackLayout>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="NUnit.Runner.View.SummaryView" Title="NUnit 3" Padding="10" BackgroundColor="{DynamicResource defaultBackground}">
+	<ContentPage.Triggers>
+		<DataTrigger TargetType="ContentPage" Binding="{Binding Running}" Value="True">
+			<Setter Property="IsBusy" Value="True" />
+		</DataTrigger>
+	</ContentPage.Triggers>
+	<StackLayout Orientation="Vertical" Spacing="4" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" BackgroundColor="{DynamicResource defaultBackground}">
+		<Button Text="Run Tests" Command="{Binding RunTestsCommand}" HorizontalOptions="FillAndExpand">
+			<Button.Triggers>
+				<DataTrigger TargetType="Button" Binding="{Binding Running}" Value="True">
+					<Setter Property="IsEnabled" Value="False" />
+				</DataTrigger>
+			</Button.Triggers>
+		</Button>
+		<ScrollView Orientation="Vertical" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" BackgroundColor="#F2F2F2" x:Name="ResultsScroller">
+			<ScrollView.Triggers>
+				<DataTrigger TargetType="ScrollView" Binding="{Binding HasResults}" Value="False">
+					<Setter Property="IsVisible" Value="False" />
+				</DataTrigger>
+			</ScrollView.Triggers>
+			<Grid HorizontalOptions="FillAndExpand" RowSpacing="0" Padding="10" BackgroundColor="White">
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition />
+					<ColumnDefinition />
+				</Grid.ColumnDefinitions>
+				<Grid.RowDefinitions>
+					<!-- Rows with height of 10 are just for spacing between sections -->
+					<RowDefinition Height="Auto" />
+					<RowDefinition Height="10" />
+					<RowDefinition Height="Auto" />
+					<RowDefinition Height="Auto" />
+					<RowDefinition Height="Auto" />
+					<RowDefinition Height="10" />
+					<RowDefinition Height="Auto" />
+					<RowDefinition Height="Auto" />
+					<RowDefinition Height="Auto" />
+					<RowDefinition Height="10" />
+					<RowDefinition Height="Auto" />
+					<RowDefinition Height="Auto" />
+					<RowDefinition Height="Auto" />
+				</Grid.RowDefinitions>
+				<StackLayout Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="4" HorizontalOptions="CenterAndExpand">
+					<Label Text="Overall result:" TextColor="{Binding Results.OverallResultColor}" FontAttributes="Bold" FontSize="Large" />
+					<Label Text="{Binding Results.OverallResult}" TextColor="{Binding Results.OverallResultColor}" FontAttributes="Bold" FontSize="Large" />
+				</StackLayout>
+				<StackLayout Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="4">
+					<Label Text="Tests run:" FontSize="Large" FontAttributes="Bold" />
+					<Label Text="{Binding Results.RunCount}" FontSize="Large" />
+				</StackLayout>
+				<StackLayout Grid.Row="3" Grid.Column="0" Orientation="Horizontal" Spacing="4">
+					<Label Text="  Passed:" FontSize="Medium" FontAttributes="Bold" />
+					<Label Text="{Binding Results.PassCount}" FontSize="Medium" />
+				</StackLayout>
+				<StackLayout Grid.Row="3" Grid.Column="1" Orientation="Horizontal" Spacing="4">
+					<Label Text="  Errors:" FontSize="Medium" FontAttributes="Bold" />
+					<Label Text="{Binding Results.ErrorCount}" FontSize="Medium" />
+				</StackLayout>
+				<StackLayout Grid.Row="4" Grid.Column="0" Orientation="Horizontal" Spacing="4">
+					<Label Text="  Inconclusive:" FontSize="Medium" FontAttributes="Bold" />
+					<Label Text="{Binding Results.InconclusiveCount}" FontSize="Medium" />
+				</StackLayout>
+				<StackLayout Grid.Row="4" Grid.Column="1" Orientation="Horizontal" Spacing="4">
+					<Label Text="  Failures:" FontSize="Medium" FontAttributes="Bold" />
+					<Label Text="{Binding Results.FailureCount}" FontSize="Medium" />
+				</StackLayout>
+				<StackLayout Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="4">
+					<Label Text="Not run:" FontSize="Large" FontAttributes="Bold" />
+					<Label Text="{Binding Results.NotRunCount}" FontSize="Large" />
+				</StackLayout>
+				<StackLayout Grid.Row="7" Grid.Column="0" Orientation="Horizontal" Spacing="4">
+					<Label Text="  Ignored:" FontSize="Medium" FontAttributes="Bold" />
+					<Label Text="{Binding Results.IgnoreCount}" FontSize="Medium" />
+				</StackLayout>
+				<StackLayout Grid.Row="7" Grid.Column="1" Orientation="Horizontal" Spacing="4">
+					<Label Text="  Explicit:" FontSize="Medium" FontAttributes="Bold" />
+					<Label Text="{Binding Results.ExplicitCount}" FontSize="Medium" />
+				</StackLayout>
+				<StackLayout Grid.Row="8" Grid.Column="0" Orientation="Horizontal" Spacing="4">
+					<Label Text="  Skipped:" FontSize="Medium" FontAttributes="Bold" />
+					<Label Text="{Binding Results.SkipCount}" FontSize="Medium" />
+				</StackLayout>
+				<StackLayout Grid.Row="8" Grid.Column="1" Orientation="Horizontal" Spacing="4">
+					<Label Text="  Invalid:" FontSize="Medium" FontAttributes="Bold" />
+					<Label Text="{Binding Results.InvalidCount}" FontSize="Medium" />
+				</StackLayout>
+				<StackLayout Grid.Row="10" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="4">
+					<Label Text="Start time:" FontSize="Small" FontAttributes="Bold" />
+					<Label Text="{Binding Results.TestResult.StartTime, StringFormat='{0:u}'}" FontSize="Small" />
+				</StackLayout>
+				<StackLayout Grid.Row="11" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="4">
+					<Label Text="End time:" FontSize="Small" FontAttributes="Bold" />
+					<Label Text="{Binding Results.TestResult.EndTime, StringFormat='{0:u}'}" FontSize="Small" />
+				</StackLayout>
+				<StackLayout Grid.Row="12" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="4">
+					<Label Text="Duration:" FontSize="Small" FontAttributes="Bold" />
+					<Label Text="{Binding Results.TestResult.Duration, StringFormat='{0:F3} seconds'}" FontSize="Small" />
+				</StackLayout>
+			</Grid>
+		</ScrollView>
+		<ScrollView Orientation="Vertical" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" BackgroundColor="#F2F2F2" x:Name="RunningScroller">
+			<ScrollView.Triggers>
+				<DataTrigger TargetType="ScrollView" Binding="{Binding HasResults}" Value="True">
+					<Setter Property="IsVisible" Value="False" />
+				</DataTrigger>
+			</ScrollView.Triggers>
+			<StackLayout Orientation="Vertical">
+				<StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand" BackgroundColor="White" Spacing="4" Padding="0">
+					<BoxView Color="{Binding RunningData.CurrentTest.Color}" WidthRequest="10" VerticalOptions="FillAndExpand" />
+					<StackLayout Orientation="Vertical" Spacing="4" Padding="4" HorizontalOptions="StartAndExpand">
+						<Label Text="{Binding RunningData.CurrentTest.Name}" FontSize="Medium" />
+						<Label Text="{Binding RunningData.CurrentTest.Parent}" LineBreakMode="MiddleTruncation" TextColor="#4C4C4C" FontSize="Small" />
+					</StackLayout>
+				</StackLayout>
+				<ListView ItemsSource="{Binding RunningData.Results}" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" HasUnevenRows="true">
+					<ListView.ItemTemplate>
+						<DataTemplate>
+							<ViewCell>
+								<ViewCell.View>
+									<StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand" BackgroundColor="White" Spacing="4" Padding="0">
+										<BoxView Color="{Binding Color}" WidthRequest="10" VerticalOptions="FillAndExpand" />
+										<StackLayout Orientation="Vertical" Spacing="4" Padding="4" HorizontalOptions="StartAndExpand">
+											<Label Text="{Binding Name}" FontSize="Medium" />
+											<Label Text="{Binding Parent}" LineBreakMode="MiddleTruncation" TextColor="#4C4C4C" FontSize="Small" />
+										</StackLayout>
+									</StackLayout>
+								</ViewCell.View>
+							</ViewCell>
+						</DataTemplate>
+					</ListView.ItemTemplate>
+				</ListView>
+				<Label VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" Text="{Binding RunningData.Status}" />
+			</StackLayout>
+		</ScrollView>
+		<Button Text="All Results" Command="{Binding ViewAllResultsCommand}" HorizontalOptions="FillAndExpand" VerticalOptions="End">
+			<Button.Triggers>
+				<DataTrigger TargetType="Button" Binding="{Binding HasResults}" Value="False">
+					<Setter Property="IsEnabled" Value="False" />
+				</DataTrigger>
+			</Button.Triggers>
+		</Button>
+		<Button Text="Failed Results" Command="{Binding ViewFailedResultsCommand}" HorizontalOptions="FillAndExpand" VerticalOptions="End">
+			<Button.Triggers>
+				<DataTrigger TargetType="Button" Binding="{Binding HasResults}" Value="False">
+					<Setter Property="IsEnabled" Value="False" />
+				</DataTrigger>
+			</Button.Triggers>
+		</Button>
+	</StackLayout>
 </ContentPage>

--- a/src/runner/nunit.runner/ViewModel/ResultViewModel.cs
+++ b/src/runner/nunit.runner/ViewModel/ResultViewModel.cs
@@ -38,6 +38,14 @@ namespace NUnit.Runner.ViewModel
             Message = result.Message;
         }
 
+		public ResultViewModel(ITest test)
+		{
+			TestResult = null;
+			Result = string.Empty;
+			Name = test.Name;
+			Parent = test.Parent?.FullName;
+		}
+
         public ITestResult TestResult { get; private set; }
         public string Result { get; set; }
         public string Name { get; private set; }

--- a/src/runner/nunit.runner/ViewModel/RunningViewModel.cs
+++ b/src/runner/nunit.runner/ViewModel/RunningViewModel.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using NUnit.Framework.Interfaces;
+using NUnit.Runner.ViewModel;
+using Xamarin.Forms;
+
+namespace NUnit.Runner
+{
+	class RunningViewModel : BaseViewModel, ITestListener
+	{
+		/// <summary>
+		/// A list of tests that did not pass
+		/// </summary>
+		public ObservableCollection<ResultViewModel> Results { get; private set; } = new ObservableCollection<ResultViewModel>();
+		public ResultViewModel CurrentTest { get; private set; } 
+
+		public void TestFinished(ITestResult result)
+		{
+			if (!result.HasChildren) Results.Insert(0, new ResultViewModel(result));
+			CurrentTest = null;
+		}
+
+		public void TestOutput(TestOutput output)
+		{
+			// not supported for running test cases
+		}
+
+		public void TestStarted(ITest test)
+		{
+			if (!test.IsSuite)
+			{
+				CurrentTest = new ResultViewModel(test);
+				OnPropertyChanged(nameof(CurrentTest));
+			}
+
+		}
+	}
+}

--- a/src/runner/nunit.runner/ViewModel/SummaryViewModel.cs
+++ b/src/runner/nunit.runner/ViewModel/SummaryViewModel.cs
@@ -47,8 +47,12 @@ namespace NUnit.Runner.ViewModel
         bool _running;
         TestResultProcessor _resultProcessor;
 
-        public SummaryViewModel()
+		readonly RunningViewModel _runningViewModel;
+
+		public SummaryViewModel()
         {
+			_runningViewModel = new RunningViewModel();
+
             _testAssemblies = new List<Assembly>();
             RunTestsCommand = new Command(async o => await ExecuteTestsAync(), o => !Running);
             ViewAllResultsCommand = new Command(
@@ -92,6 +96,12 @@ namespace NUnit.Runner.ViewModel
             }
         }
 
+		public RunningViewModel RunningData
+		{
+			get
+			{
+				return _runningViewModel;}}
+
         /// <summary>
         /// True if tests are currently running
         /// </summary>
@@ -128,11 +138,11 @@ namespace NUnit.Runner.ViewModel
         async Task ExecuteTestsAync()
         {
             Running = true;
-            Results = null;
+			Results = null;
 
             var runner = await LoadTestAssembliesAsync().ConfigureAwait(false);
 
-            ITestResult result = await Task.Run(() => runner.Run(TestListener.NULL, TestFilter.Empty)).ConfigureAwait(false);
+            ITestResult result = await Task.Run(() => runner.Run(_runningViewModel, TestFilter.Empty)).ConfigureAwait(false);
 
             _resultProcessor = TestResultProcessor.BuildChainOfResponsability(Options);
             await _resultProcessor.Process(result).ConfigureAwait(false);

--- a/src/runner/nunit.runner/nunit.runner.projitems
+++ b/src/runner/nunit.runner/nunit.runner.projitems
@@ -41,6 +41,7 @@
       <DependentUpon>TestView.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)ViewModel\RunningViewModel.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)View\TestView.xaml">

--- a/src/tests/nunit.runner.tests/AsyncTests.cs
+++ b/src/tests/nunit.runner.tests/AsyncTests.cs
@@ -58,5 +58,20 @@ namespace NUnit.Runner.Tests
         {
             return await Task.FromResult(true);
         }
+
+		[Test]
+		public async Task TestFailingLongTest()
+		{
+			await Task.Delay(1500);
+			Assert.Fail("Need to fail");
+		}
+
+		[Test]
+		public async Task TestLongTest()
+		{
+			await Task.Delay(3000);
+		}
+
+
     }
 }


### PR DESCRIPTION
I had some tests that sometimes locked up. So I was really missing some progress information to identify the culprit. This pull request adds the running progress by showing the current test and the finished tests and the results.

The diff on the SummaryView.xaml is a bit confusing, but I added a second scrollview and made sure only one of both (progress or running tests) is visible. So there are only some additions.

Thanks for this work, the current implementation provided by Xamarin as implemented in the Forms template is just... awful...