### PR TITLE
Fix UWP runner

### DIFF
--- a/src/tests/nunit.runner.tests.uwp/MainPage.xaml
+++ b/src/tests/nunit.runner.tests.uwp/MainPage.xaml
@@ -5,7 +5,7 @@
     xmlns:local="using:NUnit.Runner.Tests"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:forms="using:Xamarin.Forms.Platform.WinRT"
+    xmlns:forms="using:Xamarin.Forms.Platform.UWP"
     mc:Ignorable="d">
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">


### PR DESCRIPTION
Today I needed to do this to get the UWP test runner to build. Looking in to it, it seems to be a required change between Xamarin Forms 1.X and 2.X - which I did in #71, although I'm not sure how I managed to miss this. Sorry!