### PR TITLE
Added the TerminateAfterExecution property to TestOptions.

### DIFF
--- a/nuget/MonoAndroid10/MainActivity.cs.txt.pp
+++ b/nuget/MonoAndroid10/MainActivity.cs.txt.pp
@@ -48,8 +48,8 @@ namespace $rootnamespace$
                 // If True, the tests will run automatically when the app starts
                 // otherwise you must run them manually.
                 AutoRun = true,
-		
-		        // If True, the application will terminate automatically after running the tests.
+
+                // If True, the application will terminate automatically after running the tests.
                 //TerminateAfterExecution = true,
 
                 // Information about the tcp listener host and port.

--- a/nuget/MonoAndroid10/MainActivity.cs.txt.pp
+++ b/nuget/MonoAndroid10/MainActivity.cs.txt.pp
@@ -48,6 +48,9 @@ namespace $rootnamespace$
                 // If True, the tests will run automatically when the app starts
                 // otherwise you must run them manually.
                 AutoRun = true,
+		
+		        // If True, the application will terminate automatically after running the tests.
+                //TerminateAfterExecution = true,
 
                 // Information about the tcp listener host and port.
                 // For now, send result as XML to the listening server.

--- a/nuget/Xamarin.iOS10/AppDelegate.cs.txt.pp
+++ b/nuget/Xamarin.iOS10/AppDelegate.cs.txt.pp
@@ -56,6 +56,9 @@ namespace $rootnamespace$
                 // otherwise you must run them manually.
                 AutoRun = true,
 
+				// If True, the application will terminate automatically after running the tests.
+                //TerminateAfterExecution = true,
+
                 // Information about the tcp listener host and port.
                 // For now, send result as XML to the listening server.
                 // TcpWriterParameters = new TcpWriterInfo("192.168.0.108", 13000),

--- a/nuget/Xamarin.iOS10/AppDelegate.cs.txt.pp
+++ b/nuget/Xamarin.iOS10/AppDelegate.cs.txt.pp
@@ -56,7 +56,7 @@ namespace $rootnamespace$
                 // otherwise you must run them manually.
                 AutoRun = true,
 
-				// If True, the application will terminate automatically after running the tests.
+                // If True, the application will terminate automatically after running the tests.
                 //TerminateAfterExecution = true,
 
                 // Information about the tcp listener host and port.

--- a/nuget/uap10.0/MainPage.xaml.cs.txt.pp
+++ b/nuget/uap10.0/MainPage.xaml.cs.txt.pp
@@ -45,6 +45,9 @@ namespace $rootnamespace$
                 // otherwise you must run them manually.
                 AutoRun = true,
 
+				// If True, the application will terminate automatically after running the tests.
+                //TerminateAfterExecution = true,
+
                 // Information about the tcp listener host and port.
                 // For now, send result as XML to the listening server.
                 // NOTE: Your UWP App must have Private Networks capability enabled

--- a/nuget/uap10.0/MainPage.xaml.cs.txt.pp
+++ b/nuget/uap10.0/MainPage.xaml.cs.txt.pp
@@ -45,7 +45,7 @@ namespace $rootnamespace$
                 // otherwise you must run them manually.
                 AutoRun = true,
 
-				// If True, the application will terminate automatically after running the tests.
+                // If True, the application will terminate automatically after running the tests.
                 //TerminateAfterExecution = true,
 
                 // Information about the tcp listener host and port.

--- a/src/runner/nunit.runner/Services/TestOptions.cs
+++ b/src/runner/nunit.runner/Services/TestOptions.cs
@@ -49,6 +49,11 @@ namespace NUnit.Runner.Services
         public bool AutoRun { get; set; }
 
         /// <summary>
+        /// If True, the application will terminate automatically after running the tests.
+        /// </summary>
+        public bool TerminateAfterExecution { get; set; }
+
+        /// <summary>
         /// Information about the tcp listener host and port.
         /// For now, send result as XML to the listening server.
         /// </summary>

--- a/src/runner/nunit.runner/ViewModel/SummaryViewModel.cs
+++ b/src/runner/nunit.runner/ViewModel/SummaryViewModel.cs
@@ -142,7 +142,10 @@ namespace NUnit.Runner.ViewModel
                     {
                         Results = new ResultSummary(result);
                         Running = false;
-                    });
+
+                    if (Options.TerminateAfterExecution)
+                        TerminateWithSuccess();
+                });
         }
 
         async Task<NUnitTestAssemblyRunner> LoadTestAssembliesAsync()
@@ -151,6 +154,18 @@ namespace NUnit.Runner.ViewModel
             foreach (var testAssembly in _testAssemblies)
                 await Task.Run(() => runner.Load(testAssembly, new Dictionary<string, object>()));
             return runner;
+        }
+
+        public static void TerminateWithSuccess()
+        {
+#if __IOS__
+            var selector = new ObjCRuntime.Selector("terminateWithSuccess");
+            UIKit.UIApplication.SharedApplication.PerformSelector(selector, UIKit.UIApplication.SharedApplication, 0);
+#elif __DROID__
+            Environment.Exit(0);
+#elif WINDOWS_UWP
+            Windows.UI.Xaml.Application.Current.Exit();
+#endif
         }
     }
 }

--- a/src/runner/nunit.runner/ViewModel/SummaryViewModel.cs
+++ b/src/runner/nunit.runner/ViewModel/SummaryViewModel.cs
@@ -162,7 +162,7 @@ namespace NUnit.Runner.ViewModel
             var selector = new ObjCRuntime.Selector("terminateWithSuccess");
             UIKit.UIApplication.SharedApplication.PerformSelector(selector, UIKit.UIApplication.SharedApplication, 0);
 #elif __DROID__
-            Environment.Exit(0);
+            System.Environment.Exit(0);
 #elif WINDOWS_UWP
             Windows.UI.Xaml.Application.Current.Exit();
 #endif

--- a/src/tests/nunit.runner.tests.Droid/MainActivity.cs
+++ b/src/tests/nunit.runner.tests.Droid/MainActivity.cs
@@ -52,6 +52,9 @@ namespace NUnit.Runner.Tests
                 // otherwise you must run them manually.
                 AutoRun = true,
 
+                // If True, the application will terminate automatically after running the tests.
+                //TerminateAfterExecution = true,
+
                 // Information about the tcp listener host and port.
                 // For now, send result as XML to the listening server.
                 //TcpWriterParameters = new TcpWriterInfo("192.168.0.108", 13000),

--- a/src/tests/nunit.runner.tests.iOS/AppDelegate.cs
+++ b/src/tests/nunit.runner.tests.iOS/AppDelegate.cs
@@ -61,6 +61,9 @@ namespace NUnit.Runner.Tests
                 // otherwise you must run them manually.
                 AutoRun = true,
 
+                // If True, the application will terminate automatically after running the tests.
+                //TerminateAfterExecution = true,
+
                 // Information about the tcp listener host and port.
                 // For now, send result as XML to the listening server.
                 //TcpWriterParameters = new TcpWriterInfo("192.168.0.108", 13000),

--- a/src/tests/nunit.runner.tests.uwp/MainPage.xaml.cs
+++ b/src/tests/nunit.runner.tests.uwp/MainPage.xaml.cs
@@ -47,6 +47,9 @@ namespace NUnit.Runner.Tests
                 // otherwise you must run them manually.
                 AutoRun = true,
 
+                // If True, the application will terminate automatically after running the tests.
+                //TerminateAfterExecution = true,
+
                 // Information about the tcp listener host and port.
                 // For now, send result as XML to the listening server.
                 // NOTE: Your UWP App must have Private Networks capability enabled


### PR DESCRIPTION
The TerminateAfterExecution property allows the app to be terminated automatically after running the tests which allows the platform specific test projects to be run as part of a CI build.

Fixes #84