### PR TITLE
Added a null check in the TestOptions get-method

### DIFF
--- a/src/runner/nunit.runner/ViewModel/SummaryViewModel.cs
+++ b/src/runner/nunit.runner/ViewModel/SummaryViewModel.cs
@@ -52,10 +52,25 @@ namespace NUnit.Runner.ViewModel
                 o => !HasResults);
         }
 
+        private TestOptions options;
+
         /// <summary>
         /// User options for the test suite.
         /// </summary>
-        public TestOptions Options { get; set; }
+        public TestOptions Options {
+            get
+            {
+                if(options == null)
+                {
+                    options = new TestOptions();
+                }
+                return options;
+            }
+            set
+            {
+                options = value;
+            }
+        }
         
         /// <summary>
         /// Called from the view when the view is appearing


### PR DESCRIPTION
I got a NullException when running the iOS runner without setting the Options property. This commit make sure that the Options property of NUnit.Runner.App is always initialized.