### PR TITLE
Update to NUnit 3.8.1 and Android 7.1

### DIFF
--- a/nuget/nunit.runners.xamarin.nuspec
+++ b/nuget/nunit.runners.xamarin.nuspec
@@ -23,7 +23,7 @@ Supported Xamarin platforms:
 
         <dependencies>
             <group>
-                <dependency id="nunit" version="3.8.1" />
+                <dependency id="nunit" version="[3.8.1]" />
                 <dependency id="Xamarin.Forms" version="1.5.0.6447" />
                 <dependency id="PCLStorage" version="1.0.2" />
             </group>

--- a/nuget/nunit.runners.xamarin.nuspec
+++ b/nuget/nunit.runners.xamarin.nuspec
@@ -23,7 +23,7 @@ Supported Xamarin platforms:
 
         <dependencies>
             <group>
-                <dependency id="nunit" version="[3.6.1]" />
+                <dependency id="nunit" version="3.8.1" />
                 <dependency id="Xamarin.Forms" version="1.5.0.6447" />
                 <dependency id="PCLStorage" version="1.0.2" />
             </group>

--- a/src/runner/nunit.runner.Droid/nunit.runner.Droid.csproj
+++ b/src/runner/nunit.runner.Droid/nunit.runner.Droid.csproj
@@ -13,11 +13,11 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/runner/nunit.runner.Droid/nunit.runner.Droid.nuget.targets
+++ b/src/runner/nunit.runner.Droid/nunit.runner.Droid.nuget.targets
@@ -4,6 +4,6 @@
     <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
   </PropertyGroup>
   <ImportGroup>
-    <Import Project="$(NuGetPackageRoot)xamarin.forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('$(NuGetPackageRoot)xamarin.forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
+    <Import Project="$(NuGetPackageRoot)\Xamarin.Forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('$(NuGetPackageRoot)\Xamarin.Forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
   </ImportGroup>
 </Project>

--- a/src/runner/nunit.runner.Droid/project.json
+++ b/src/runner/nunit.runner.Droid/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NUnit": "3.8.1",
+    "NUnit": "[3.8.1]",
     "PCLStorage": "1.0.2",
     "Xamarin.Forms": "1.5.0.6447"
   },

--- a/src/runner/nunit.runner.Droid/project.json
+++ b/src/runner/nunit.runner.Droid/project.json
@@ -1,11 +1,11 @@
 ﻿{
   "dependencies": {
-    "NUnit": "3.6.1",
+    "NUnit": "3.8.1",
     "PCLStorage": "1.0.2",
     "Xamarin.Forms": "1.5.0.6447"
   },
   "frameworks": {
-    "monoandroid60": {}
+    "monoandroid71": {}
   },
   "runtimes": {
     "win": {}

--- a/src/runner/nunit.runner.iOS/nunit.runner.iOS.nuget.targets
+++ b/src/runner/nunit.runner.iOS/nunit.runner.iOS.nuget.targets
@@ -4,6 +4,6 @@
     <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
   </PropertyGroup>
   <ImportGroup>
-    <Import Project="$(NuGetPackageRoot)xamarin.forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('$(NuGetPackageRoot)xamarin.forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
+    <Import Project="$(NuGetPackageRoot)\Xamarin.Forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('$(NuGetPackageRoot)\Xamarin.Forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
   </ImportGroup>
 </Project>

--- a/src/runner/nunit.runner.iOS/project.json
+++ b/src/runner/nunit.runner.iOS/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NUnit": "3.6.1",
+    "NUnit": "3.8.1",
     "PCLStorage": "1.0.2",
     "Xamarin.Forms": "1.5.0.6447"
   },

--- a/src/runner/nunit.runner.iOS/project.json
+++ b/src/runner/nunit.runner.iOS/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NUnit": "3.8.1",
+    "NUnit": "[3.8.1]",
     "PCLStorage": "1.0.2",
     "Xamarin.Forms": "1.5.0.6447"
   },

--- a/src/runner/nunit.runner.uwp/nunit.runner.uwp.nuget.targets
+++ b/src/runner/nunit.runner.uwp/nunit.runner.uwp.nuget.targets
@@ -4,6 +4,6 @@
     <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
   </PropertyGroup>
   <ImportGroup>
-    <Import Project="$(NuGetPackageRoot)xamarin.forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('$(NuGetPackageRoot)xamarin.forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
+    <Import Project="$(NuGetPackageRoot)\Xamarin.Forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('$(NuGetPackageRoot)\Xamarin.Forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
   </ImportGroup>
 </Project>

--- a/src/runner/nunit.runner.uwp/project.json
+++ b/src/runner/nunit.runner.uwp/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
-    "NUnit": "3.6.1",
+    "NUnit": "3.8.1",
     "PCLStorage": "1.0.2",
     "Xamarin.Forms": "1.5.0.6447"
   },

--- a/src/runner/nunit.runner.uwp/project.json
+++ b/src/runner/nunit.runner.uwp/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
-    "NUnit": "3.8.1",
+    "NUnit": "[3.8.1]",
     "PCLStorage": "1.0.2",
     "Xamarin.Forms": "1.5.0.6447"
   },

--- a/src/tests/nunit.runner.tests.Droid/nunit.runner.tests.Droid.csproj
+++ b/src/tests/nunit.runner.tests.Droid/nunit.runner.tests.Droid.csproj
@@ -14,7 +14,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
     <AndroidSupportedAbis>armeabi,armeabi-v7a,x86</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions />
     <MandroidI18n />
@@ -24,7 +24,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/tests/nunit.runner.tests.Droid/nunit.runner.tests.Droid.nuget.targets
+++ b/src/tests/nunit.runner.tests.Droid/nunit.runner.tests.Droid.nuget.targets
@@ -4,6 +4,6 @@
     <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
   </PropertyGroup>
   <ImportGroup>
-    <Import Project="$(NuGetPackageRoot)xamarin.forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('$(NuGetPackageRoot)xamarin.forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
+    <Import Project="$(NuGetPackageRoot)\Xamarin.Forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('$(NuGetPackageRoot)\Xamarin.Forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
   </ImportGroup>
 </Project>

--- a/src/tests/nunit.runner.tests.Droid/project.json
+++ b/src/tests/nunit.runner.tests.Droid/project.json
@@ -1,10 +1,10 @@
 ﻿{
   "dependencies": {
-    "NUnit": "3.6.1",
+    "NUnit": "3.8.1",
     "Xamarin.Forms": "1.5.0.6447"
   },
   "frameworks": {
-    "monoandroid60": {}
+    "monoandroid71": {}
   },
   "runtimes": {
     "win": {}

--- a/src/tests/nunit.runner.tests.Droid/project.json
+++ b/src/tests/nunit.runner.tests.Droid/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NUnit": "3.8.1",
+    "NUnit": "[3.8.1]",
     "Xamarin.Forms": "1.5.0.6447"
   },
   "frameworks": {

--- a/src/tests/nunit.runner.tests.iOS/nunit.runner.tests.iOS.nuget.targets
+++ b/src/tests/nunit.runner.tests.iOS/nunit.runner.tests.iOS.nuget.targets
@@ -4,6 +4,6 @@
     <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
   </PropertyGroup>
   <ImportGroup>
-    <Import Project="$(NuGetPackageRoot)xamarin.forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('$(NuGetPackageRoot)xamarin.forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
+    <Import Project="$(NuGetPackageRoot)\Xamarin.Forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('$(NuGetPackageRoot)\Xamarin.Forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
   </ImportGroup>
 </Project>

--- a/src/tests/nunit.runner.tests.iOS/project.json
+++ b/src/tests/nunit.runner.tests.iOS/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NUnit": "3.6.1",
+    "NUnit": "3.8.1",
     "Xamarin.Forms": "1.5.0.6447"
   },
   "frameworks": {

--- a/src/tests/nunit.runner.tests.iOS/project.json
+++ b/src/tests/nunit.runner.tests.iOS/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NUnit": "3.8.1",
+    "NUnit": "[3.8.1]",
     "Xamarin.Forms": "1.5.0.6447"
   },
   "frameworks": {

--- a/src/tests/nunit.runner.tests.uwp/nunit.runner.tests.uwp.nuget.targets
+++ b/src/tests/nunit.runner.tests.uwp/nunit.runner.tests.uwp.nuget.targets
@@ -4,6 +4,6 @@
     <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
   </PropertyGroup>
   <ImportGroup>
-    <Import Project="$(NuGetPackageRoot)xamarin.forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('$(NuGetPackageRoot)xamarin.forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
+    <Import Project="$(NuGetPackageRoot)\Xamarin.Forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('$(NuGetPackageRoot)\Xamarin.Forms\1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
   </ImportGroup>
 </Project>

--- a/src/tests/nunit.runner.tests.uwp/project.json
+++ b/src/tests/nunit.runner.tests.uwp/project.json
@@ -4,7 +4,7 @@
     "Microsoft.ApplicationInsights.PersistenceChannel": "1.2.3",
     "Microsoft.ApplicationInsights.WindowsApps": "1.1.1",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
-    "NUnit": "3.6.1",
+    "NUnit": "3.8.1",
     "Xamarin.Forms": "1.5.0.6447"
   },
   "frameworks": {

--- a/src/tests/nunit.runner.tests.uwp/project.json
+++ b/src/tests/nunit.runner.tests.uwp/project.json
@@ -4,7 +4,7 @@
     "Microsoft.ApplicationInsights.PersistenceChannel": "1.2.3",
     "Microsoft.ApplicationInsights.WindowsApps": "1.1.1",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
-    "NUnit": "3.8.1",
+    "NUnit": "[3.8.1]",
     "Xamarin.Forms": "1.5.0.6447"
   },
   "frameworks": {


### PR DESCRIPTION
Updated NUnit Xamarin to use reference NUnit 3.8.1 and Android 7.1.  This includes updating the nuspec file to reference NUnit 3.8.1.  Left the Xamarin Forms dependence as is 1.5.0.6447.

See issue #87 for more details.