### PR TITLE
Enable setting custom test context parameters

### DIFF
--- a/src/nunit.xamarin/App.xaml.cs
+++ b/src/nunit.xamarin/App.xaml.cs
@@ -59,9 +59,9 @@ namespace NUnit.Runner
         /// Adds an assembly to be tested.
         /// </summary>
         /// <param name="testAssembly">The test assembly.</param>
-        public void AddTestAssembly(Assembly testAssembly)
+        public void AddTestAssembly(Assembly testAssembly, Dictionary<string, object> options = null)
         {
-            _model.AddTest(testAssembly);
+            _model.AddTest(testAssembly, options);
         }
 
         /// <summary>

--- a/src/nunit.xamarin/App.xaml.cs
+++ b/src/nunit.xamarin/App.xaml.cs
@@ -21,6 +21,7 @@
 // ***********************************************************************
 
 using System.Reflection;
+using System.Collections.Generic;
 
 using NUnit.Runner.Services;
 using NUnit.Runner.View;

--- a/src/nunit.xamarin/Helpers/TestPackage.cs
+++ b/src/nunit.xamarin/Helpers/TestPackage.cs
@@ -35,20 +35,20 @@ namespace NUnit.Runner.Helpers
     /// </summary>
     internal class TestPackage
     {
-        private readonly List<Assembly> _testAssemblies = new List<Assembly>();
+        private readonly List<(Assembly, Dictionary<string,object>)> _testAssemblies = new List<(Assembly, Dictionary<string,object>)>();
 
-        public void AddAssembly(Assembly testAssembly)
+        public void AddAssembly(Assembly testAssembly, Dictionary<string,object> options = null)
         {
-            _testAssemblies.Add(testAssembly);
+            _testAssemblies.Add( (testAssembly, options) );
         }
 
         public async Task<TestRunResult> ExecuteTests()
         {
             var resultPackage = new TestRunResult();
 
-            foreach (var assembly in _testAssemblies)
+            foreach (var (assembly,options) in _testAssemblies)
             {
-                NUnitTestAssemblyRunner runner = await LoadTestAssemblyAsync(assembly).ConfigureAwait(false);
+                NUnitTestAssemblyRunner runner = await LoadTestAssemblyAsync(assembly, options).ConfigureAwait(false);
                 ITestResult result = await Task.Run(() => runner.Run(TestListener.NULL, TestFilter.Empty)).ConfigureAwait(false);
                 resultPackage.AddResult(result);
             }
@@ -56,10 +56,10 @@ namespace NUnit.Runner.Helpers
             return resultPackage;
         }
 
-        private static async Task<NUnitTestAssemblyRunner> LoadTestAssemblyAsync(Assembly assembly)
+        private static async Task<NUnitTestAssemblyRunner> LoadTestAssemblyAsync(Assembly assembly, Dictionary<string, object> options)
         {
             var runner = new NUnitTestAssemblyRunner(new DefaultTestAssemblyBuilder());
-            await Task.Run(() => runner.Load(assembly, new Dictionary<string, object>()));
+            await Task.Run(() => runner.Load(assembly, options ?? new Dictionary<string, object>()));
             return runner;
         }
     }

--- a/src/nunit.xamarin/ViewModel/SummaryViewModel.cs
+++ b/src/nunit.xamarin/ViewModel/SummaryViewModel.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System.Reflection;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using NUnit.Runner.Helpers;
@@ -128,9 +129,9 @@ namespace NUnit.Runner.ViewModel
         /// </summary>
         /// <param name="testAssembly">The test assembly.</param>
         /// <returns></returns>
-        internal void AddTest(Assembly testAssembly)
+        internal void AddTest(Assembly testAssembly, Dictionary<string, object> options = null)
         {
-            _testPackage.AddAssembly(testAssembly);
+            _testPackage.AddAssembly(testAssembly, options);
         }
 
         async Task ExecuteTestsAync()


### PR DESCRIPTION
Fixes #107 

Takes an optional extra argument during AddTestAssembly, and passes it to NUnitTestAssemblyRunner.