### PR TITLE
Fixing test duration info

### DIFF
--- a/src/nunit.xamarin/Helpers/ResultSummary.cs
+++ b/src/nunit.xamarin/Helpers/ResultSummary.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
@@ -46,6 +47,8 @@ namespace NUnit.Runner.Helpers
             _results = results;
             Initialize();
             Summarize(results.TestResults);
+            StartTime = results.StartTime;
+            EndTime = results.EndTime;
         }
 
         #endregion
@@ -109,8 +112,7 @@ namespace NUnit.Runner.Helpers
         /// <summary>
         /// Gets the color for the overall result.
         /// </summary>
-        public Color OverallResultColor
-        {
+        public Color OverallResultColor {
             get { return new ResultState(OverallResult).Color(); }
         }
 
@@ -134,8 +136,7 @@ namespace NUnit.Runner.Helpers
         /// <summary>
         /// Returns the number of test cases not run for any reason.
         /// </summary>
-        public int NotRunCount
-        {
+        public int NotRunCount {
             get { return IgnoreCount + ExplicitCount + InvalidCount + SkipCount; }
         }
 
@@ -180,6 +181,23 @@ namespace NUnit.Runner.Helpers
         /// Gets the count of tests not run because the are Explicit
         /// </summary>
         public int ExplicitCount { get; private set; }
+
+        /// <summary>
+        /// Gets the time when the tests started running
+        /// </summary>
+        public DateTime StartTime { get; private set; }
+
+        /// <summary>
+        /// Gets the time when the tests ended it's execution
+        /// </summary>
+        public DateTime EndTime { get; private set; }
+
+        /// <summary>
+        /// Gets how long it took to execute the tests
+        /// </summary>
+        public TimeSpan Duration {
+            get { return EndTime.Subtract(StartTime); }
+        }
 
         #endregion
 

--- a/src/nunit.xamarin/Helpers/ResultSummary.cs
+++ b/src/nunit.xamarin/Helpers/ResultSummary.cs
@@ -185,12 +185,12 @@ namespace NUnit.Runner.Helpers
         public int ExplicitCount { get; private set; }
 
         /// <summary>
-        /// Gets the time when the tests started running
+        /// Gets the time when the test suite started running
         /// </summary>
         public DateTime StartTime { get; private set; }
 
         /// <summary>
-        /// Gets the time when the tests ended it's execution
+        /// Gets the time when the test suite completed execution
         /// </summary>
         public DateTime EndTime { get; private set; }
 

--- a/src/nunit.xamarin/Helpers/ResultSummary.cs
+++ b/src/nunit.xamarin/Helpers/ResultSummary.cs
@@ -112,7 +112,8 @@ namespace NUnit.Runner.Helpers
         /// <summary>
         /// Gets the color for the overall result.
         /// </summary>
-        public Color OverallResultColor {
+        public Color OverallResultColor
+        {
             get { return new ResultState(OverallResult).Color(); }
         }
 
@@ -136,7 +137,8 @@ namespace NUnit.Runner.Helpers
         /// <summary>
         /// Returns the number of test cases not run for any reason.
         /// </summary>
-        public int NotRunCount {
+        public int NotRunCount
+        {
             get { return IgnoreCount + ExplicitCount + InvalidCount + SkipCount; }
         }
 
@@ -195,7 +197,8 @@ namespace NUnit.Runner.Helpers
         /// <summary>
         /// Gets how long it took to execute the tests
         /// </summary>
-        public TimeSpan Duration {
+        public TimeSpan Duration 
+        {
             get { return EndTime.Subtract(StartTime); }
         }
 

--- a/src/nunit.xamarin/View/SummaryView.xaml
+++ b/src/nunit.xamarin/View/SummaryView.xaml
@@ -101,15 +101,15 @@
 
                 <StackLayout Grid.Row="10" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="4">
                     <Label Text="Start time:" FontSize="Small" FontAttributes="Bold" />
-                    <Label Text="{Binding Results.TestResult.StartTime, StringFormat='{0:u}'}" FontSize="Small" />
+                    <Label Text="{Binding Results.StartTime, StringFormat='{0:u}'}" FontSize="Small" />
                 </StackLayout>
                 <StackLayout Grid.Row="11" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="4">
                     <Label Text="End time:" FontSize="Small" FontAttributes="Bold" />
-                    <Label Text="{Binding Results.TestResult.EndTime, StringFormat='{0:u}'}" FontSize="Small" />
+                    <Label Text="{Binding Results.EndTime, StringFormat='{0:u}'}" FontSize="Small" />
                 </StackLayout>
                 <StackLayout Grid.Row="12" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="4">
                     <Label Text="Duration:" FontSize="Small" FontAttributes="Bold" />
-                    <Label Text="{Binding Results.TestResult.Duration, StringFormat='{0:F3} seconds'}" FontSize="Small" />
+                    <Label Text="{Binding Results.Duration, StringFormat='{0:s\\.fff} seconds'}" FontSize="Small" />
                 </StackLayout>
             </Grid>
 


### PR DESCRIPTION
This fix the issue #97 
Data about tests execution time does not appear in the results.

