### PR TITLE
Explore button + ability to run individual tests

### DIFF
--- a/src/nunit.xamarin/Extensions/XamarinExtensions.cs
+++ b/src/nunit.xamarin/Extensions/XamarinExtensions.cs
@@ -22,6 +22,9 @@
 // ***********************************************************************
 
 using NUnit.Framework.Interfaces;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using Xamarin.Forms;
 
 namespace NUnit.Runner.Extensions
@@ -52,6 +55,16 @@ namespace NUnit.Runner.Extensions
                 case TestStatus.Inconclusive:
                 default:
                     return Xamarin.Forms.Color.Gray;
+            }
+        }
+
+        public static IEnumerable<string> PropertyValues(this ITest test, string propertyName)
+        {
+            if (!test.Properties.ContainsKey(propertyName)) yield break;
+            else
+            {
+                for (int i = 0; i < test.Properties[propertyName].Count; i++)
+                    yield return test.Properties[propertyName][i]?.ToString();
             }
         }
     }

--- a/src/nunit.xamarin/View/SummaryView.xaml
+++ b/src/nunit.xamarin/View/SummaryView.xaml
@@ -11,13 +11,22 @@
         </DataTrigger>
     </ContentPage.Triggers>
     <StackLayout Orientation="Vertical" Spacing="4" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" BackgroundColor="{DynamicResource defaultBackground}">
-        <Button Text="Run Tests" Command="{Binding RunTestsCommand}"  HorizontalOptions="FillAndExpand">
-            <Button.Triggers>
-                <DataTrigger TargetType="Button" Binding="{Binding Running}" Value="True">
-                    <Setter Property="IsEnabled" Value="False" />
-                </DataTrigger>
-            </Button.Triggers>
-        </Button>
+        <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand">
+            <Button Text="Run Tests" Command="{Binding RunTestsCommand}"  HorizontalOptions="StartAndExpand">
+                <Button.Triggers>
+                    <DataTrigger TargetType="Button" Binding="{Binding Running}" Value="True">
+                        <Setter Property="IsEnabled" Value="False" />
+                    </DataTrigger>
+                </Button.Triggers>
+            </Button>
+            <Button Text="Explore" Command="{Binding ExploreTestsCommand}"  HorizontalOptions="EndAndExpand">
+                <Button.Triggers>
+                    <DataTrigger TargetType="Button" Binding="{Binding Running}" Value="True">
+                        <Setter Property="IsEnabled" Value="False" />
+                    </DataTrigger>
+                </Button.Triggers>
+            </Button>
+        </StackLayout>
 
         <ScrollView Orientation="Vertical"
                     VerticalOptions="FillAndExpand" 

--- a/src/nunit.xamarin/View/TestExplorerView.xaml
+++ b/src/nunit.xamarin/View/TestExplorerView.xaml
@@ -16,7 +16,7 @@
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <ViewCell>
-                        <StackLayout Orientation="Horizontal"  VerticalOptions="Center">
+                        <StackLayout Orientation="Horizontal"  VerticalOptions="Center" Padding="5">
                             <Label VerticalOptions="Center" FontSize="Small" Text="{Binding FullName}" VerticalTextAlignment="Center" />
                             <StackLayout.GestureRecognizers>
                                 <TapGestureRecognizer Command="{Binding Source={x:Reference testExplorerPage}, Path=BindingContext.RunTestCommand}"  NumberOfTapsRequired="2" CommandParameter="{Binding .}"/>
@@ -28,8 +28,8 @@
             <ListView.GroupHeaderTemplate>
                 <DataTemplate>
                     <ViewCell>
-                        <Grid >
-                            <Label BackgroundColor="#005B0C" FontAttributes="Bold" Text="{Binding GroupName}" FontSize="Small" TextColor="White" VerticalTextAlignment="Center" />
+                        <Grid BackgroundColor="#005B0C" >
+                            <Label Margin="5" FontAttributes="Bold" Text="{Binding GroupName}" FontSize="Small" TextColor="White" VerticalTextAlignment="Center" />
                         </Grid>
                     </ViewCell>
                 </DataTemplate>

--- a/src/nunit.xamarin/View/TestExplorerView.xaml
+++ b/src/nunit.xamarin/View/TestExplorerView.xaml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             Title="Test Explorer"
+             Padding="10"
+             BackgroundColor="{DynamicResource defaultBackground}" 
+             x:Class="NUnit.Runner.View.TestExplorerView">
+    <ContentPage.Triggers>
+        <DataTrigger TargetType="ContentPage" Binding="{Binding Loading}" Value="True">
+            <Setter Property="IsBusy" Value="True" />
+        </DataTrigger>
+    </ContentPage.Triggers>
+    <StackLayout Orientation="Vertical" Spacing="4" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" BackgroundColor="{DynamicResource defaultBackground}">
+        <ListView IsGroupingEnabled="True" ItemsSource="{Binding TestList}">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <ViewCell>
+                        <StackLayout Orientation="Horizontal"  VerticalOptions="Center">
+                            <Label VerticalOptions="Center" FontSize="Small" Text="{Binding FullName}" VerticalTextAlignment="Center" />
+                        </StackLayout>
+                    </ViewCell>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+            <ListView.GroupHeaderTemplate>
+                <DataTemplate>
+                    <ViewCell>
+                        <Grid >
+                            <Label BackgroundColor="#005B0C" FontAttributes="Bold" Text="{Binding GroupName}" FontSize="Small" TextColor="White" VerticalTextAlignment="Center" />
+                        </Grid>
+                    </ViewCell>
+                </DataTemplate>
+            </ListView.GroupHeaderTemplate>
+        </ListView>
+
+    </StackLayout>
+</ContentPage>

--- a/src/nunit.xamarin/View/TestExplorerView.xaml
+++ b/src/nunit.xamarin/View/TestExplorerView.xaml
@@ -4,9 +4,10 @@
              Title="Test Explorer"
              Padding="10"
              BackgroundColor="{DynamicResource defaultBackground}" 
+             x:Name="testExplorerPage"
              x:Class="NUnit.Runner.View.TestExplorerView">
     <ContentPage.Triggers>
-        <DataTrigger TargetType="ContentPage" Binding="{Binding Loading}" Value="True">
+        <DataTrigger TargetType="ContentPage" Binding="{Binding Busy}" Value="True">
             <Setter Property="IsBusy" Value="True" />
         </DataTrigger>
     </ContentPage.Triggers>
@@ -17,6 +18,9 @@
                     <ViewCell>
                         <StackLayout Orientation="Horizontal"  VerticalOptions="Center">
                             <Label VerticalOptions="Center" FontSize="Small" Text="{Binding FullName}" VerticalTextAlignment="Center" />
+                            <StackLayout.GestureRecognizers>
+                                <TapGestureRecognizer Command="{Binding Source={x:Reference testExplorerPage}, Path=BindingContext.RunTestCommand}"  NumberOfTapsRequired="2" CommandParameter="{Binding .}"/>
+                            </StackLayout.GestureRecognizers>
                         </StackLayout>
                     </ViewCell>
                 </DataTemplate>

--- a/src/nunit.xamarin/View/TestExplorerView.xaml
+++ b/src/nunit.xamarin/View/TestExplorerView.xaml
@@ -17,7 +17,7 @@
                 <DataTemplate>
                     <ViewCell>
                         <StackLayout Orientation="Horizontal"  VerticalOptions="Center" Padding="5">
-                            <Label VerticalOptions="Center" FontSize="Small" Text="{Binding FullName}" VerticalTextAlignment="Center" />
+                            <Label VerticalOptions="Center" FontSize="Small" Text="{Binding Name}" VerticalTextAlignment="Center" />
                             <StackLayout.GestureRecognizers>
                                 <TapGestureRecognizer Command="{Binding Source={x:Reference testExplorerPage}, Path=BindingContext.RunTestCommand}"  NumberOfTapsRequired="2" CommandParameter="{Binding .}"/>
                             </StackLayout.GestureRecognizers>

--- a/src/nunit.xamarin/View/TestExplorerView.xaml.cs
+++ b/src/nunit.xamarin/View/TestExplorerView.xaml.cs
@@ -1,0 +1,43 @@
+﻿using NUnit.Runner.Messages;
+using NUnit.Runner.ViewModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace NUnit.Runner.View
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class TestExplorerView : ContentPage
+    {
+        TestExplorerViewModel _model;
+
+        internal TestExplorerView(TestExplorerViewModel model)
+        {
+            _model = model;
+            _model.Navigation = Navigation;
+            BindingContext = _model;
+            InitializeComponent();
+
+            MessagingCenter.Subscribe<ErrorMessage>(this, ErrorMessage.Name, error =>
+            {
+                Device.BeginInvokeOnMainThread(async () => await DisplayAlert("Error", error.Message, "OK"));
+            });
+        }
+
+        /// <summary>
+        /// Called when the view is appearing
+        /// </summary>
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            _model.LoadTestsAsync();
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+        }
+    }
+}

--- a/src/nunit.xamarin/ViewModel/GroupedTestsViewModel.cs
+++ b/src/nunit.xamarin/ViewModel/GroupedTestsViewModel.cs
@@ -1,0 +1,43 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 NUnit Project
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+
+namespace NUnit.Runner.ViewModel
+{
+    class GroupedTestsViewModel : ObservableCollection<TestDescriptionViewModel>
+    {
+        public GroupedTestsViewModel(string groupName, IEnumerable<TestDescriptionViewModel> tests)
+        {
+            GroupName = groupName;
+            foreach (var test in (tests ?? Enumerable.Empty<TestDescriptionViewModel>())) 
+                Items.Add(test);
+        }
+
+        public string GroupName { get; }
+    }
+}

--- a/src/nunit.xamarin/ViewModel/SummaryViewModel.cs
+++ b/src/nunit.xamarin/ViewModel/SummaryViewModel.cs
@@ -31,6 +31,7 @@ using NUnit.Runner.View;
 using NUnit.Runner.Services;
 
 using Xamarin.Forms;
+using System.Linq;
 
 namespace NUnit.Runner.ViewModel
 {
@@ -45,6 +46,7 @@ namespace NUnit.Runner.ViewModel
         {
             _testPackage = new TestPackage();
             RunTestsCommand = new Command(async o => await ExecuteTestsAync(), o => !Running);
+            ExploreTestsCommand = new Command(async o => await Navigation.PushAsync(new TestExplorerView(new TestExplorerViewModel(_testPackage))), o => !Running);
             ViewAllResultsCommand = new Command(
                 async o => await Navigation.PushAsync(new ResultsView(new ResultsViewModel(_results.GetTestResults(), true))),
                 o => !HasResults);
@@ -123,6 +125,7 @@ namespace NUnit.Runner.ViewModel
         public ICommand RunTestsCommand { set; get; }
         public ICommand ViewAllResultsCommand { set; get; }
         public ICommand ViewFailedResultsCommand { set; get; }
+        public ICommand ExploreTestsCommand { get; set; }
 
         /// <summary>
         /// Adds an assembly to be tested.
@@ -138,6 +141,7 @@ namespace NUnit.Runner.ViewModel
         {
             Running = true;
             Results = null;
+
             TestRunResult results = await _testPackage.ExecuteTests();
             ResultSummary summary = new ResultSummary(results);
 

--- a/src/nunit.xamarin/ViewModel/SummaryViewModel.cs
+++ b/src/nunit.xamarin/ViewModel/SummaryViewModel.cs
@@ -46,7 +46,9 @@ namespace NUnit.Runner.ViewModel
         {
             _testPackage = new TestPackage();
             RunTestsCommand = new Command(async o => await ExecuteTestsAync(), o => !Running);
-            ExploreTestsCommand = new Command(async o => await Navigation.PushAsync(new TestExplorerView(new TestExplorerViewModel(_testPackage))), o => !Running);
+            
+            ExploreTestsCommand = new Command(async o => await Navigation.PushAsync(new TestExplorerView(new TestExplorerViewModel(_testPackage, this) { Navigation = Navigation})), o => !Running);
+
             ViewAllResultsCommand = new Command(
                 async o => await Navigation.PushAsync(new ResultsView(new ResultsViewModel(_results.GetTestResults(), true))),
                 o => !HasResults);
@@ -156,6 +158,21 @@ namespace NUnit.Runner.ViewModel
 
                     if (Options.TerminateAfterExecution)
                         TerminateWithSuccess();
+                });
+        }
+
+        internal async Task DisplayResults(TestRunResult results)
+        {
+            ResultSummary summary = new ResultSummary(results);
+
+            _resultProcessor = TestResultProcessor.BuildChainOfResponsability(Options);
+            await _resultProcessor.Process(summary).ConfigureAwait(false);
+
+            Device.BeginInvokeOnMainThread(
+                () =>
+                {
+                    Results = summary;
+                    Running = false;
                 });
         }
 

--- a/src/nunit.xamarin/ViewModel/TestDescriptionViewModel.cs
+++ b/src/nunit.xamarin/ViewModel/TestDescriptionViewModel.cs
@@ -1,0 +1,71 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 NUnit Project
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NUnit.Framework.Interfaces;
+using NUnit.Runner.Extensions;
+using NUnit.Runner.ViewModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NUnit.Runner.ViewModel
+{
+    class TestDescriptionViewModel : BaseViewModel
+    {
+        public TestDescriptionViewModel(ITest test, string assembly)
+        {
+            _test = test;
+            MethodName = StringOrUnknown(_test.MethodName);
+            ClassName = StringOrUnknown(_test.ClassName);
+            FullName = StringOrUnknown(_test.FullName);
+            Assembly = assembly;
+            Categories = _test.PropertyValues("Category").ToArray();
+        }
+
+        private readonly ITest _test;
+        public string MethodName { get; }
+        public string ClassName { get; }
+        public string FullName { get; }
+        public string Assembly { get; }
+        public string[] Categories { get; }
+
+        private bool _selected;
+        
+        /// <summary>
+        /// True if test is selected
+        /// </summary>
+        public bool Selected
+        {
+            get { return _selected; }
+            set
+            {
+                if (value.Equals(_selected)) return;
+                _selected = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private string StringOrUnknown(string str) => string.IsNullOrWhiteSpace(str) ? "<unknown>" : str;        
+    }
+}

--- a/src/nunit.xamarin/ViewModel/TestDescriptionViewModel.cs
+++ b/src/nunit.xamarin/ViewModel/TestDescriptionViewModel.cs
@@ -36,6 +36,7 @@ namespace NUnit.Runner.ViewModel
         public TestDescriptionViewModel(ITest test, string assembly)
         {
             _test = test;
+            Name = StringOrUnknown(_test.Name);
             MethodName = StringOrUnknown(_test.MethodName);
             ClassName = StringOrUnknown(_test.ClassName);
             FullName = StringOrUnknown(_test.FullName);
@@ -44,6 +45,7 @@ namespace NUnit.Runner.ViewModel
         }
 
         private readonly ITest _test;
+        public string Name { get; }
         public string MethodName { get; }
         public string ClassName { get; }
         public string FullName { get; }

--- a/src/nunit.xamarin/ViewModel/TestExplorerViewModel.cs
+++ b/src/nunit.xamarin/ViewModel/TestExplorerViewModel.cs
@@ -1,0 +1,83 @@
+﻿// ***********************************************************************
+// Copyright (c) 2015 NUnit Project
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NUnit.Runner.Helpers;
+using NUnit.Runner.ViewModel;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.Forms;
+
+namespace NUnit.Runner.ViewModel
+{
+    class TestExplorerViewModel : BaseViewModel
+    {
+        readonly TestPackage _testPackage;
+        bool _loading;
+
+        public TestExplorerViewModel(TestPackage testPackage)
+        {
+            _testPackage = testPackage;
+            TestList = new ObservableCollection<GroupedTestsViewModel>();
+        }
+
+        public async Task LoadTestsAsync()
+        {
+            var groupedTests = (await _testPackage.EnumerateTestsAsync()).GroupBy(t => t.Test.ClassName);
+            Device.BeginInvokeOnMainThread(() =>
+            {
+                Loading = true;
+
+                TestList.Clear();
+
+                foreach (var testClass in groupedTests)
+                {
+                    TestList.Add(new GroupedTestsViewModel(testClass.Key, testClass.Select(t => new TestDescriptionViewModel(t.Test, t.Assembly))));
+                }
+
+                Loading = false;
+            });          
+        } 
+
+        public ObservableCollection<GroupedTestsViewModel> TestList { get; }
+
+        /// <summary>
+        /// True if tests are being loaded or grouped
+        /// </summary>
+        public bool Loading
+        {
+            get { return _loading; }
+            set
+            {
+                if (value.Equals(_loading)) return;
+                _loading = value;
+                OnPropertyChanged();
+            }
+        }
+
+
+    }
+}

--- a/src/nunit.xamarin/nunit.xamarin.csproj
+++ b/src/nunit.xamarin/nunit.xamarin.csproj
@@ -36,5 +36,14 @@ Supported Xamarin platforms:
     <Compile Condition=" '$(EnableDefaultCompileItems)' == 'true' " Update="App.xaml.cs">
       <DependentUpon>*.xaml</DependentUpon>
     </Compile>
+    <Compile Update="View\TestExplorerView.xaml.cs">
+      <DependentUpon>TestExplorerView.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="View\TestExplorerView.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This change addresses #29, #14, and #46 

An "Explore" button is added to the Summary View. This opens a list of tests grouped by class (my initial intention was to have a dropdown which will allow grouping by Category, Class, Assembly, etc., but I am not sure I'll have the time to include this). Double-tapping a test will run it and show the results in the Summary page.

New ViewModels:
- **TestExplorerViewModel** - this is the main viewmodel bound to the test explorer view
- **TestDescriptionViewModel** - view model representing a single test case
- **GroupedTestsViewModel** - view model representing a set of test cases in the same group 

New Views:
- **TestExplorerView** - test explorer view

Screenshots:
1. Updated summary view
![image](https://user-images.githubusercontent.com/1549544/164145407-7ac5dd99-37d5-480f-9de8-cd48de649677.png)

2. Explore view
![image](https://user-images.githubusercontent.com/1549544/164145437-dc4604fb-0566-410a-96ce-c1e1c36dbd1f.png)

